### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/GroupLima/SAR-Repo/security/code-scanning/6](https://github.com/GroupLima/SAR-Repo/security/code-scanning/6)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow only involves checking out the repository and running tests, it likely only requires `contents: read` permissions. This change will explicitly limit the permissions of the `GITHUB_TOKEN` to the minimum required for the workflow to function correctly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
