### PR TITLE
Connections

### DIFF
--- a/search-app/back-end/app/Http/Controllers/RecordController.php
+++ b/search-app/back-end/app/Http/Controllers/RecordController.php
@@ -33,17 +33,18 @@ class RecordController extends Controller
             $command = "python3 $python_search_file $permitted_params";
             //extracts the json output object
             $raw_output = shell_exec($command);
+            //echo $raw_output;
+            //echo $raw_output["results"];
             $output = json_decode($raw_output, true);
             
             //store matches list
             $match_results = $output["results"];
-
+            
             // add xml content to each entry in every page of the volume
             foreach ($match_results as $page) {
                 foreach ($page['records'] as &$record){
                     $entry_id = $record['id'];
                     $xml_path = $record['xmlpath'];
-
                     // add xml content to record
                     $record['xml_content'] = $this->get_xml_content($entry_id, $xml_path);
                     
@@ -51,7 +52,7 @@ class RecordController extends Controller
                     unset($record['xmlpath']);
                     }
             };
-
+            //$echo $match_results;
             // Check if $this->match_results is not null and is an array
             $num_pages = (is_array($match_results) && count($match_results) > 0) ? count($match_results) : 0;
             
@@ -77,8 +78,9 @@ class RecordController extends Controller
     }
     
     public function get_xml_content($entry_id, $xml_path){
+        $path = base_path($xml_path);
         // load the xml as a simple xml element
-        $xml_file = simplexml_load_file($xml_path);
+        $xml_file = simplexml_load_file($path);
 
         // Register the TEI namespace
         $xml_file->registerXPathNamespace('tei', $this->TEI_namespace);

--- a/search-app/back-end/app/Http/Controllers/RecordController.php
+++ b/search-app/back-end/app/Http/Controllers/RecordController.php
@@ -8,7 +8,6 @@ class RecordController extends Controller
 {
     public function getVolumes()
     {
-        // Static for now; can be made dynamic later
         return response()->json([
             1 => 20,
             2 => 15,
@@ -56,8 +55,10 @@ class RecordController extends Controller
                         $id = (string) $entry['xml:id'];
                         $lang = (string) $entry['xml:lang'];
 
-                        if ($type === 'entry' && str_contains($id, 'ARO-' . $volume . '-')) {
-                            // Attempt to extract date from parent <div> if present
+                        // TEMPORARY: Match all <div type="entry"> for testing
+                        if ($type === 'entry') {
+                            \Log::info("Matched entry: $id");
+
                             $date = '';
                             if (isset($div->p->date['when'])) {
                                 $date = (string) $div->p->date['when'];
@@ -75,7 +76,6 @@ class RecordController extends Controller
             }
         }
 
-        // Pagination
         $perPage = 10;
         $offset = ($page - 1) * $perPage;
         $paginated = array_slice($records, $offset, $perPage);

--- a/search-app/back-end/app/Http/Controllers/RecordController.php
+++ b/search-app/back-end/app/Http/Controllers/RecordController.php
@@ -41,13 +41,13 @@ class RecordController extends Controller
             $match_results = $output["results"];
             
             // add xml content to each entry in every page of the volume
-            foreach ($match_results as $page) {
+            foreach ($match_results as &$page) {
                 foreach ($page['records'] as &$record){
                     $entry_id = $record['id'];
                     $xml_path = $record['xmlpath'];
                     // add xml content to record
                     $record['xml_content'] = $this->get_xml_content($entry_id, $xml_path);
-                    
+                    //echo $record['xml_content'];
                     // dont need to return the xmlpath so remove it
                     unset($record['xmlpath']);
                     }
@@ -90,16 +90,10 @@ class RecordController extends Controller
 
         // Check if the entry exists
         if (!empty($target_xml)) {
-            return $target_xml[0]; // Return the first match (or the only match)
+            return $target_xml[0]->asXML(); // Return the first match (or the only match)
         } else {
             return null; // Return null if no entry found
         }
-
-        // 1. asXML converts simple xml into a string format
-        // 2. htmlentities turns xml into a string and escapes special characters
-        // 3. nl2br implements new lines as <br> html tag
-        $converted_xml = nl2br(htmlentities($target_xml->asXML()));
-        return $converted_xml;
     }
 
     // public function getVolumes()

--- a/search-app/back-end/app/Http/Controllers/RecordController.php
+++ b/search-app/back-end/app/Http/Controllers/RecordController.php
@@ -77,6 +77,11 @@ class RecordController extends Controller
         return '../resources/python/browse_search.py';
     }
     
+
+    /*
+    XML file naming system:
+    ARO-(beginning_volume)-(beginning_page)-(beginning_chapter)_ARO-(ending_volume)-(ending_page)-(ending_chapter).xml
+    */
     public function get_xml_content($entry_id, $xml_path){
         $path = base_path($xml_path);
         // load the xml as a simple xml element
@@ -95,151 +100,4 @@ class RecordController extends Controller
             return null; // Return null if no entry found
         }
     }
-
-    // public function getVolumes()
-    // {
-    //     return response()->json([
-    //         1 => 20,
-    //         2 => 15,
-    //         4 => 25,
-    //         5 => 18,
-    //         6 => 22,
-    //         7 => 16,
-    //         8 => 19,
-    //     ]);
-    // }
-
-    // public function getRecords(Request $request)
-    // {   
-    //     $volume = $request->query('volume');
-
-    //     if (!$volume) {
-    //         return response()->json(['error' => 'Volume and page are required'], 400);
-    //     }
-
-    //     $directories = [
-    //         storage_path('app/xml-files/XML files volumes 1-7'),
-    //         storage_path('app/xml-files/XML files volume 8'),
-    //     ];
-
-    //     $records = [];
-
-    //     // prepare to iterate through all entries of
-    //     $entries = $this->jsonData[$volume] ?? [];
-
-
-
-        
-    //     foreach ($directories as $dir) {
-    //         if (!is_dir($dir)) {
-    //             \Log::error("Directory not found: $dir");
-    //             continue;
-    //         }
-
-    //         foreach (scandir($dir) as $file) {
-    //             if (!str_ends_with($file, '.xml')) continue;
-
-    //             $filePath = $dir . DIRECTORY_SEPARATOR . $file;
-    //             \Log::info("Processing file: $filePath");
-
-    //             libxml_use_internal_errors(true);
-    //             $xml = simplexml_load_file($filePath);
-
-    //             if (!$xml) {
-    //                 \Log::error("Failed to parse XML: " . print_r(libxml_get_errors(), true));
-    //                 continue;
-    //             }
-
-    //             $xml->registerXPathNamespace('tei', 'http://www.tei-c.org/ns/1.0');
-    //             $xml->registerXPathNamespace('xml', 'http://www.w3.org/XML/1998/namespace');
-
-    //             $entries = $xml->xpath('//tei:div[@type="entry" or @type="incompleteEntry"]');
-
-    //             foreach ($entries as $entry) {
-    //                 $id = (string)$entry->attributes('xml', true)->id;
-    //                 $lang = (string)$entry->attributes('xml', true)->lang;
-
-    //                 // Filter for volume
-    //                 if (!str_starts_with($id, 'ARO-' . $volume . '-')) {
-    //                     continue;
-    //                 }
-
-    //                 // Get date from previous sibling
-    //                 $date = '';
-    //                 $precedingElements = $entry->xpath('preceding-sibling::tei:p[1]/tei:date[@when]');
-    //                 if (!empty($precedingElements)) {
-    //                     $date = (string)$precedingElements[0]['when'];
-    //                 }
-
-    //                 $content = '';
-    //                 if ($entry->head) {
-    //                     $content .= (string)$entry->head . "\n";
-    //                 }
-    //                 if ($entry->p) {
-    //                     $content .= strip_tags($entry->p->asXML());
-    //                 }
-
-    //                 $records[] = [
-    //                     'id' => $id,
-    //                     'language' => $lang,
-    //                     'content' => $content,
-    //                     'date' => $date,
-    //                 ];
-
-    //                 \Log::info("Found entry: $id");
-    //             }
-    //         }
-    //     }
-
-    //     $perPage = 10;
-    //     $offset = ($page - 1) * $perPage;
-    //     $paginated = array_slice($records, $offset, $perPage);
-
-    //     return response()->json([
-    //         'records' => $paginated,
-    //         'total' => count($records),
-    //     ]);
-    // }
-
-    
-
-    // public function getXml($id)
-    // {
-    //     $directories = [
-    //         storage_path('app/xml-files/XML files volumes 1-7'),
-    //         storage_path('app/xml-files/XML files volume 8'),
-    //     ];
-
-    //     foreach ($directories as $dir) {
-    //         if (!is_dir($dir)) continue;
-
-    //         foreach (scandir($dir) as $file) {
-    //             if (!str_ends_with($file, '.xml')) continue;
-
-    //             $filePath = $dir . DIRECTORY_SEPARATOR . $file;
-    //             libxml_use_internal_errors(true);
-    //             $xml = simplexml_load_file($filePath);
-    //             if (!$xml) continue;
-
-    //             $xml->registerXPathNamespace('tei', 'http://www.tei-c.org/ns/1.0');
-    //             $xml->registerXPathNamespace('xml', 'http://www.w3.org/XML/1998/namespace');
-
-    //             $entries = $xml->xpath('//tei:div[@xml:id="' . $id . '"]');
-    //             if (!empty($entries)) {
-    //                 $entry = $entries[0];
-    //                 $dom = dom_import_simplexml($entry);
-    //                 $xmlDoc = new \DOMDocument();
-    //                 $xmlDoc->preserveWhiteSpace = false;
-    //                 $xmlDoc->formatOutput = true;
-    //                 $xmlDoc->appendChild($xmlDoc->importNode($dom, true));
-
-    //                 libxml_clear_errors();
-    //                 return response($xmlDoc->saveXML(), 200)
-    //                     ->header('Content-Type', 'application/xml');
-    //             }
-    //         }
-    //     }
-
-    //     return response()->json(['error' => 'XML entry not found'], 404);
-    // }
 }

--- a/search-app/back-end/app/Http/Controllers/RecordController.php
+++ b/search-app/back-end/app/Http/Controllers/RecordController.php
@@ -56,7 +56,7 @@ class RecordController extends Controller
                         $id = (string) $entry['xml:id'];
                         $lang = (string) $entry['xml:lang'];
 
-                        if ($type === 'entry' && str_starts_with($id, 'ARO-' . $volume . '-')) {
+                        if ($type === 'entry' && str_contains($id, 'ARO-' . $volume . '-')) {
                             // Attempt to extract date from parent <div> if present
                             $date = '';
                             if (isset($div->p->date['when'])) {

--- a/search-app/back-end/app/Http/Controllers/RecordController.php
+++ b/search-app/back-end/app/Http/Controllers/RecordController.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class RecordController extends Controller
+{
+    public function getVolumes()
+    {
+        // Example static data (you can fetch from DB later)
+        return response()->json([
+            1 => 20,
+            2 => 15,
+            4 => 25,
+            5 => 18,
+            6 => 22,
+            7 => 16,
+            8 => 19,
+        ]);
+    }
+
+    public function getRecords(Request $request)
+    {
+        $volume = $request->query('volume');
+        $page = $request->query('page');
+
+        // Example static records (replace with DB query later)
+        return response()->json([
+            'records' => [
+                [
+                    'id' => 'ARO-1-0001-01',
+                    'date' => '1398-09-30',
+                    'language' => 'Latin',
+                    'content' => 'H Processus Curiarum Balliuorum Isti Sunt...'
+                ],
+                [
+                    'id' => 'ARO-1-0001-02',
+                    'date' => '1398-09-30',
+                    'language' => 'Latin',
+                    'content' => 'Quo die Willelmus de Camera pater cum...'
+                ]
+            ]
+        ]);
+    }
+
+    public function getXml($id)
+    {
+        $directories = [
+            storage_path('xml-files/XML files volumes 1-7'),
+            storage_path('xml-files/XML files volume 8'),
+        ];
+    
+        foreach ($directories as $dir) {
+            if (!is_dir($dir)) continue;
+    
+            $files = scandir($dir);
+    
+            foreach ($files as $file) {
+                if (str_starts_with($file, $id) && str_ends_with($file, '.xml')) {
+                    $fullPath = $dir . DIRECTORY_SEPARATOR . $file;
+                    $content = file_get_contents($fullPath);
+    
+                    return response($content, 200)
+                        ->header('Content-Type', 'application/xml');
+                }
+            }
+        }
+    
+        return response()->json(['error' => 'XML file not found'], 404);
+    }
+    
+}

--- a/search-app/back-end/app/Http/Controllers/RecordController.php
+++ b/search-app/back-end/app/Http/Controllers/RecordController.php
@@ -2,147 +2,248 @@
 
 namespace App\Http\Controllers;
 
+use Illuminate\Validation\ValidationException;
 use Illuminate\Http\Request;
+
 
 class RecordController extends Controller
 {
-    public function getVolumes()
+    protected $TEI_namespace;
+
+    public function __construct()
     {
-        return response()->json([
-            1 => 20,
-            2 => 15,
-            4 => 25,
-            5 => 18,
-            6 => 22,
-            7 => 16,
-            8 => 19,
-        ]);
+        // register TEI namespace for accessing xml files
+        $this->TEI_namespace = 'http://www.tei-c.org/ns/1.0';
     }
 
     public function getRecords(Request $request)
     {
-        $volume = $request->query('volume');
-        $page = $request->query('page');
+        try {
+            $volume = $request->query('volume');
+            // convert from front end to back end naming conventions
+            $permitted = [];
+            $permitted['vol'] = $volume ?? null;
+            //get search script based on query type eg. xquery, basic_search, advanced_search, autocomplete, autocomplete entry
+            $python_search_file = $this->get_browse_path();
+            
+            //get matches from any type of search
+            $permitted_params = escapeshellarg(json_encode($permitted));
+            
+            //$command = "python3 $python_search_file_arg $permitted_params";
+            $command = "python3 $python_search_file $permitted_params";
+            //extracts the json output object
+            $raw_output = shell_exec($command);
+            $output = json_decode($raw_output, true);
+            
+            //store matches list
+            $match_results = $output["results"];
 
-        if (!$volume || !$page) {
-            return response()->json(['error' => 'Volume and page are required'], 400);
+            // add xml content to each entry in every page of the volume
+            foreach ($match_results as $page) {
+                foreach ($page['records'] as &$record){
+                    $entry_id = $record['id'];
+                    $xml_path = $record['xmlpath'];
+
+                    // add xml content to record
+                    $record['xml_content'] = $this->get_xml_content($entry_id, $xml_path);
+                    
+                    // dont need to return the xmlpath so remove it
+                    unset($record['xmlpath']);
+                    }
+            };
+
+            // Check if $this->match_results is not null and is an array
+            $num_pages = (is_array($match_results) && count($match_results) > 0) ? count($match_results) : 0;
+            
+            // Return the JSON response with the validated data
+            return response()->json([
+                'success' => true,
+                'num_pages' => $num_pages,
+                'records' => $match_results,
+                'message' => $output['message'],
+            ]);
+
+        } catch (ValidationException $e){
+            return response()->json([
+                'success' => false,
+                'message' => 'Invalid parameters for browse search',
+                //route to valid error page eventually
+            ]);
         }
-
-        $directories = [
-            storage_path('app/xml-files/XML files volumes 1-7'),
-            storage_path('app/xml-files/XML files volume 8'),
-        ];
-
-        $records = [];
-
-        foreach ($directories as $dir) {
-            if (!is_dir($dir)) {
-                \Log::error("Directory not found: $dir");
-                continue;
-            }
-
-            foreach (scandir($dir) as $file) {
-                if (!str_ends_with($file, '.xml')) continue;
-
-                $filePath = $dir . DIRECTORY_SEPARATOR . $file;
-                \Log::info("Processing file: $filePath");
-
-                libxml_use_internal_errors(true);
-                $xml = simplexml_load_file($filePath);
-
-                if (!$xml) {
-                    \Log::error("Failed to parse XML: " . print_r(libxml_get_errors(), true));
-                    continue;
-                }
-
-                $xml->registerXPathNamespace('tei', 'http://www.tei-c.org/ns/1.0');
-                $xml->registerXPathNamespace('xml', 'http://www.w3.org/XML/1998/namespace');
-
-                $entries = $xml->xpath('//tei:div[@type="entry" or @type="incompleteEntry"]');
-
-                foreach ($entries as $entry) {
-                    $id = (string)$entry->attributes('xml', true)->id;
-                    $lang = (string)$entry->attributes('xml', true)->lang;
-
-                    // Filter for volume
-                    if (!str_starts_with($id, 'ARO-' . $volume . '-')) {
-                        continue;
-                    }
-
-                    // Get date from previous sibling
-                    $date = '';
-                    $precedingElements = $entry->xpath('preceding-sibling::tei:p[1]/tei:date[@when]');
-                    if (!empty($precedingElements)) {
-                        $date = (string)$precedingElements[0]['when'];
-                    }
-
-                    $content = '';
-                    if ($entry->head) {
-                        $content .= (string)$entry->head . "\n";
-                    }
-                    if ($entry->p) {
-                        $content .= strip_tags($entry->p->asXML());
-                    }
-
-                    $records[] = [
-                        'id' => $id,
-                        'language' => $lang,
-                        'content' => $content,
-                        'date' => $date,
-                    ];
-
-                    \Log::info("Found entry: $id");
-                }
-            }
-        }
-
-        $perPage = 10;
-        $offset = ($page - 1) * $perPage;
-        $paginated = array_slice($records, $offset, $perPage);
-
-        return response()->json([
-            'records' => $paginated,
-            'total' => count($records),
-        ]);
     }
 
-    public function getXml($id)
-    {
-        $directories = [
-            storage_path('app/xml-files/XML files volumes 1-7'),
-            storage_path('app/xml-files/XML files volume 8'),
-        ];
+    public function get_browse_path(){
+        return '../resources/python/browse_search.py';
+    }
+    
+    public function get_xml_content($entry_id, $xml_path){
+        // load the xml as a simple xml element
+        $xml_file = simplexml_load_file($xml_path);
 
-        foreach ($directories as $dir) {
-            if (!is_dir($dir)) continue;
+        // Register the TEI namespace
+        $xml_file->registerXPathNamespace('tei', $this->TEI_namespace);
+        
+        // get entry where xml:id is $id
+        $target_xml = $xml_file->xpath("//tei:div[@xml:id='{$entry_id}']");
 
-            foreach (scandir($dir) as $file) {
-                if (!str_ends_with($file, '.xml')) continue;
-
-                $filePath = $dir . DIRECTORY_SEPARATOR . $file;
-                libxml_use_internal_errors(true);
-                $xml = simplexml_load_file($filePath);
-                if (!$xml) continue;
-
-                $xml->registerXPathNamespace('tei', 'http://www.tei-c.org/ns/1.0');
-                $xml->registerXPathNamespace('xml', 'http://www.w3.org/XML/1998/namespace');
-
-                $entries = $xml->xpath('//tei:div[@xml:id="' . $id . '"]');
-                if (!empty($entries)) {
-                    $entry = $entries[0];
-                    $dom = dom_import_simplexml($entry);
-                    $xmlDoc = new \DOMDocument();
-                    $xmlDoc->preserveWhiteSpace = false;
-                    $xmlDoc->formatOutput = true;
-                    $xmlDoc->appendChild($xmlDoc->importNode($dom, true));
-
-                    libxml_clear_errors();
-                    return response($xmlDoc->saveXML(), 200)
-                        ->header('Content-Type', 'application/xml');
-                }
-            }
+        // Check if the entry exists
+        if (!empty($target_xml)) {
+            return $target_xml[0]; // Return the first match (or the only match)
+        } else {
+            return null; // Return null if no entry found
         }
 
-        return response()->json(['error' => 'XML entry not found'], 404);
+        // 1. asXML converts simple xml into a string format
+        // 2. htmlentities turns xml into a string and escapes special characters
+        // 3. nl2br implements new lines as <br> html tag
+        $converted_xml = nl2br(htmlentities($target_xml->asXML()));
+        return $converted_xml;
     }
+
+    // public function getVolumes()
+    // {
+    //     return response()->json([
+    //         1 => 20,
+    //         2 => 15,
+    //         4 => 25,
+    //         5 => 18,
+    //         6 => 22,
+    //         7 => 16,
+    //         8 => 19,
+    //     ]);
+    // }
+
+    // public function getRecords(Request $request)
+    // {   
+    //     $volume = $request->query('volume');
+
+    //     if (!$volume) {
+    //         return response()->json(['error' => 'Volume and page are required'], 400);
+    //     }
+
+    //     $directories = [
+    //         storage_path('app/xml-files/XML files volumes 1-7'),
+    //         storage_path('app/xml-files/XML files volume 8'),
+    //     ];
+
+    //     $records = [];
+
+    //     // prepare to iterate through all entries of
+    //     $entries = $this->jsonData[$volume] ?? [];
+
+
+
+        
+    //     foreach ($directories as $dir) {
+    //         if (!is_dir($dir)) {
+    //             \Log::error("Directory not found: $dir");
+    //             continue;
+    //         }
+
+    //         foreach (scandir($dir) as $file) {
+    //             if (!str_ends_with($file, '.xml')) continue;
+
+    //             $filePath = $dir . DIRECTORY_SEPARATOR . $file;
+    //             \Log::info("Processing file: $filePath");
+
+    //             libxml_use_internal_errors(true);
+    //             $xml = simplexml_load_file($filePath);
+
+    //             if (!$xml) {
+    //                 \Log::error("Failed to parse XML: " . print_r(libxml_get_errors(), true));
+    //                 continue;
+    //             }
+
+    //             $xml->registerXPathNamespace('tei', 'http://www.tei-c.org/ns/1.0');
+    //             $xml->registerXPathNamespace('xml', 'http://www.w3.org/XML/1998/namespace');
+
+    //             $entries = $xml->xpath('//tei:div[@type="entry" or @type="incompleteEntry"]');
+
+    //             foreach ($entries as $entry) {
+    //                 $id = (string)$entry->attributes('xml', true)->id;
+    //                 $lang = (string)$entry->attributes('xml', true)->lang;
+
+    //                 // Filter for volume
+    //                 if (!str_starts_with($id, 'ARO-' . $volume . '-')) {
+    //                     continue;
+    //                 }
+
+    //                 // Get date from previous sibling
+    //                 $date = '';
+    //                 $precedingElements = $entry->xpath('preceding-sibling::tei:p[1]/tei:date[@when]');
+    //                 if (!empty($precedingElements)) {
+    //                     $date = (string)$precedingElements[0]['when'];
+    //                 }
+
+    //                 $content = '';
+    //                 if ($entry->head) {
+    //                     $content .= (string)$entry->head . "\n";
+    //                 }
+    //                 if ($entry->p) {
+    //                     $content .= strip_tags($entry->p->asXML());
+    //                 }
+
+    //                 $records[] = [
+    //                     'id' => $id,
+    //                     'language' => $lang,
+    //                     'content' => $content,
+    //                     'date' => $date,
+    //                 ];
+
+    //                 \Log::info("Found entry: $id");
+    //             }
+    //         }
+    //     }
+
+    //     $perPage = 10;
+    //     $offset = ($page - 1) * $perPage;
+    //     $paginated = array_slice($records, $offset, $perPage);
+
+    //     return response()->json([
+    //         'records' => $paginated,
+    //         'total' => count($records),
+    //     ]);
+    // }
+
+    
+
+    // public function getXml($id)
+    // {
+    //     $directories = [
+    //         storage_path('app/xml-files/XML files volumes 1-7'),
+    //         storage_path('app/xml-files/XML files volume 8'),
+    //     ];
+
+    //     foreach ($directories as $dir) {
+    //         if (!is_dir($dir)) continue;
+
+    //         foreach (scandir($dir) as $file) {
+    //             if (!str_ends_with($file, '.xml')) continue;
+
+    //             $filePath = $dir . DIRECTORY_SEPARATOR . $file;
+    //             libxml_use_internal_errors(true);
+    //             $xml = simplexml_load_file($filePath);
+    //             if (!$xml) continue;
+
+    //             $xml->registerXPathNamespace('tei', 'http://www.tei-c.org/ns/1.0');
+    //             $xml->registerXPathNamespace('xml', 'http://www.w3.org/XML/1998/namespace');
+
+    //             $entries = $xml->xpath('//tei:div[@xml:id="' . $id . '"]');
+    //             if (!empty($entries)) {
+    //                 $entry = $entries[0];
+    //                 $dom = dom_import_simplexml($entry);
+    //                 $xmlDoc = new \DOMDocument();
+    //                 $xmlDoc->preserveWhiteSpace = false;
+    //                 $xmlDoc->formatOutput = true;
+    //                 $xmlDoc->appendChild($xmlDoc->importNode($dom, true));
+
+    //                 libxml_clear_errors();
+    //                 return response($xmlDoc->saveXML(), 200)
+    //                     ->header('Content-Type', 'application/xml');
+    //             }
+    //         }
+    //     }
+
+    //     return response()->json(['error' => 'XML entry not found'], 404);
+    // }
 }

--- a/search-app/back-end/app/Http/Controllers/RecordController.php
+++ b/search-app/back-end/app/Http/Controllers/RecordController.php
@@ -8,7 +8,7 @@ class RecordController extends Controller
 {
     public function getVolumes()
     {
-        // Example static data (you can fetch from DB later)
+        // Example static data (can later be replaced with a DB query)
         return response()->json([
             1 => 20,
             2 => 15,
@@ -22,23 +22,23 @@ class RecordController extends Controller
 
     public function getRecords(Request $request)
     {
-        $volume = $request->query('volume');
-        $page = $request->query('page');
+        $volume = $request->query('volume', 1); // Default to 1 if not set
+        $page = $request->query('page', 1);     // Default to 1 if not set
 
-        // Example static records (replace with DB query later)
+        // Generate 2 dummy records dynamically based on volume and page
         return response()->json([
             'records' => [
                 [
-                    'id' => 'ARO-1-0001-01',
+                    'id' => "ARO-{$volume}-{$page}-01",
                     'date' => '1398-09-30',
                     'language' => 'Latin',
-                    'content' => 'H Processus Curiarum Balliuorum Isti Sunt...'
+                    'content' => "Record 1 from Volume {$volume}, Page {$page}"
                 ],
                 [
-                    'id' => 'ARO-1-0001-02',
+                    'id' => "ARO-{$volume}-{$page}-02",
                     'date' => '1398-09-30',
                     'language' => 'Latin',
-                    'content' => 'Quo die Willelmus de Camera pater cum...'
+                    'content' => "Record 2 from Volume {$volume}, Page {$page}"
                 ]
             ]
         ]);
@@ -50,24 +50,23 @@ class RecordController extends Controller
             storage_path('xml-files/XML files volumes 1-7'),
             storage_path('xml-files/XML files volume 8'),
         ];
-    
+
         foreach ($directories as $dir) {
             if (!is_dir($dir)) continue;
-    
+
             $files = scandir($dir);
-    
+
             foreach ($files as $file) {
                 if (str_starts_with($file, $id) && str_ends_with($file, '.xml')) {
                     $fullPath = $dir . DIRECTORY_SEPARATOR . $file;
                     $content = file_get_contents($fullPath);
-    
+
                     return response($content, 200)
                         ->header('Content-Type', 'application/xml');
                 }
             }
         }
-    
+
         return response()->json(['error' => 'XML file not found'], 404);
     }
-    
 }

--- a/search-app/back-end/app/Http/Controllers/SearchController.php
+++ b/search-app/back-end/app/Http/Controllers/SearchController.php
@@ -253,6 +253,22 @@ search_controller   ->  15. sorted results (html text, other match data, entry d
         return $htmltext;
     }
 
+    public function getRawEntry(Request $request){
+        $entry_id = $request->query('docId');
+        if (isset($this->jsonData[$entry_id])){
+            return response()->json([
+                'success' => true,
+                'content' => $this->jsonData[$entry_id]['content'],
+                'volume' => $this->jsonData[$entry_id]['volume'],
+                'page' => $this->jsonData[$entry_id]['page'],
+                'date' => $this->jsonData[$entry_id]['date'],
+                'lang' => $this->jsonData[$entry_id]['lang'],
+            ]);
+        } else {
+            return response()->json(['success' => false]);
+        }
+    }
+
 
     public function runXQuery(Request $request)
     {

--- a/search-app/back-end/app/Http/Controllers/SearchController.php
+++ b/search-app/back-end/app/Http/Controllers/SearchController.php
@@ -164,14 +164,8 @@ search_controller   ->  15. sorted results (html text, other match data, entry d
     }
 
 
-    function get_search_path($query_type){
-        //$query_type = $permitted['qt'];
-        if (strtolower($query_type) == 'xquery'){
-            //hardcoded for now
-            return '../resources/python/XQuerySearch.py';
-        } else {
-            return '../resources/python/Search.py' ;
-        }
+    function get_search_path(){
+        return '../resources/python/Search.py';
     }
 
     function filter_and_format($permitted) {

--- a/search-app/back-end/resources/python/Search.py
+++ b/search-app/back-end/resources/python/Search.py
@@ -3,7 +3,6 @@ import json
 from rapidfuzz import process, fuzz
 from advanced_search import Advanced_Search
 from basic_search import Basic_Search
-import json_parser as Json_Parser
 import sort_methods
 
 from pathlib import Path

--- a/search-app/back-end/resources/python/browse_search.py
+++ b/search-app/back-end/resources/python/browse_search.py
@@ -8,8 +8,8 @@ from pathlib import Path
 
 class BrowseSearch():
 
-    def __init__(self, params):
-        self.json_entries = self.load_json()
+    def __init__(self, params, json_entries):
+        self.json_entries = json_entries or self.load_json()
         self.params = params
 
         self.vol = 1
@@ -19,15 +19,15 @@ class BrowseSearch():
         try:
             self.vol = self.params.get('vol')
             # attempt to convert to integer
-            self.vol = int(self.vol)
+            self.vol = [int(self.vol)]
 
             # use advanced search to get all entries in a single volume
-            search_obj = AdvancedSearch(None, None, self.vol, None, None, None)
-            adv_matches = search_obj.filter_entries(json_entries)
+            search_obj = Advanced_Search(None, None, self.vol, None, None, None)
+            adv_matches = search_obj.filter_entries(self.json_entries)
 
             # sort and format results
             grouped_entries = sort_methods.sort_browse_entries_into_list(adv_matches)
-            self.matches = self.normalize_attributes(sorted_entries)
+            self.matches = self.normalize_attributes(grouped_entries)
         except:
             raise BrowseError(self.vol)
 
@@ -37,7 +37,7 @@ class BrowseSearch():
             json_entries = json.load(json_file)
         return json_entries
 
-    def format_date(date):
+    def format_date(self, date):
         if date.get("when"):
             return date["when"]
         elif date.get("from") and date.get("to"):

--- a/search-app/back-end/resources/python/browse_search.py
+++ b/search-app/back-end/resources/python/browse_search.py
@@ -61,7 +61,7 @@ class BrowseSearch():
                 date = entry.get("date")
                 entry["date"] = self.format_date(date)
 
-                lang = entry.get("language")
+                lang = entry.get("lang")
                 entry["lang"] = self.get_full_language(lang)
         return grouped_entries
 

--- a/search-app/back-end/resources/python/browse_search.py
+++ b/search-app/back-end/resources/python/browse_search.py
@@ -1,0 +1,87 @@
+import sys
+import json
+from advanced_search import Advanced_Search
+import sort_methods
+from errors.custom_errors import BrowseError
+
+from pathlib import Path
+
+class BrowseSearch():
+
+    def __init__(self, params):
+        self.json_entries = self.load_json()
+        self.params = params
+
+        self.vol = 1
+        self.matches = []
+
+    def start(self):
+        try:
+            self.vol = self.params.get('vol')
+            # attempt to convert to integer
+            self.vol = int(self.vol)
+
+            # use advanced search to get all entries in a single volume
+            search_obj = AdvancedSearch(None, None, self.vol, None, None, None)
+            adv_matches = search_obj.filter_entries(json_entries)
+
+            # sort and format results
+            grouped_entries = sort_methods.sort_browse_entries_into_list(adv_matches)
+            self.matches = self.normalize_attributes(sorted_entries)
+        except:
+            raise BrowseError(self.vol)
+
+    def load_json(self):
+        json_filepath = Path(__file__).resolve().parent.parent / 'json' / 'entries.json'
+        with open(json_filepath, 'r') as json_file:
+            json_entries = json.load(json_file)
+        return json_entries
+
+    def format_date(date):
+        if date.get("when"):
+            return date["when"]
+        elif date.get("from") and date.get("to"):
+            return f"{date['from']} - {date['to']}"
+        elif date.get("from"):
+            return f"{datej['from']} -"
+        elif date.get("to"):
+            return f"- {date['to']}"
+        return ''
+
+    def get_full_language(self, lang):
+        match lang:
+            case 'la': return 'Latin'
+            case 'sc' : return 'Middle Scots'
+            case 'mul' : return 'Multiple'
+            case _: return ''
+
+    def normalize_attributes(self, grouped_entries):
+        for page in grouped_entries:
+            for entry in page["records"]:
+                date = entry.get("date")
+                entry["date"] = self.format_date(date)
+
+                lang = entry.get("language")
+                entry["lang"] = self.get_full_language(lang)
+        return grouped_entries
+
+    def get_matches(self):
+        return self.matches
+
+if __name__ == '__main__':
+    if len(sys.argv) > 1:
+        permitted = json.loads(sys.argv[1])
+        browse_search = BrowseSearch(permitted)
+        search.start()
+        matches = search.get_matches()
+        if matches:
+            results = {"message": "matches found", "results": matches}
+        else:
+            results = {"message": "no matches found", "results": None}
+        print(json.dumps(results)) # return the matches data in a JSON object
+    else:
+        arglen = len(sys.argv)
+        results = {"message":  "Not enough arguments. Need parameters.", "results": arglen}
+        print(json.dumps(results))
+        #print(json.dumps({"error": "Not enough arguments. Need parameters."}))
+    

--- a/search-app/back-end/resources/python/browse_search.py
+++ b/search-app/back-end/resources/python/browse_search.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 class BrowseSearch():
 
-    def __init__(self, params, json_entries):
+    def __init__(self, params, json_entries=None):
         self.json_entries = json_entries or self.load_json()
         self.params = params
 
@@ -72,8 +72,8 @@ if __name__ == '__main__':
     if len(sys.argv) > 1:
         permitted = json.loads(sys.argv[1])
         browse_search = BrowseSearch(permitted)
-        search.start()
-        matches = search.get_matches()
+        browse_search.start()
+        matches = browse_search.get_matches()
         if matches:
             results = {"message": "matches found", "results": matches}
         else:

--- a/search-app/back-end/resources/python/errors/custom_errors.py
+++ b/search-app/back-end/resources/python/errors/custom_errors.py
@@ -14,6 +14,6 @@ class InvalidDateInputError(Exception):
     def __init__(self, date):
         super().__init__(f"Invalid date input: {date} \nShould be in the form YYYY-MM-DD")
 
-class BrowseSearchError(Exception):
+class BrowseError(Exception):
     def __init__(self, volume):
-        super().__init__(f"Something went wrong using BrowseSearch class: '\n{message}' is the value assigned to self.vol")
+        super().__init__(f"Something went wrong using BrowseSearch class: '\n{volume}' is the value assigned to self.vol")

--- a/search-app/back-end/resources/python/errors/custom_errors.py
+++ b/search-app/back-end/resources/python/errors/custom_errors.py
@@ -13,3 +13,7 @@ class InvalidVolumeInputError(Exception):
 class InvalidDateInputError(Exception):
     def __init__(self, date):
         super().__init__(f"Invalid date input: {date} \nShould be in the form YYYY-MM-DD")
+
+class BrowseSearchError(Exception):
+    def __init__(self, volume):
+        super().__init__(f"Something went wrong using BrowseSearch class: '\n{message}' is the value assigned to self.vol")

--- a/search-app/back-end/resources/python/sort_methods.py
+++ b/search-app/back-end/resources/python/sort_methods.py
@@ -41,6 +41,7 @@ return example:
 """
 # considers page numbers with letters as well ex. 130A
 def split_page_key(page):
+    print(page)
     match = re.match(r'^(\d+)([a-zA-Z]?)$', str(page))
     number = int(match.group(1))
     letter = match.group(2).lower() if match.group(2) else ''
@@ -141,14 +142,17 @@ def sort_chronological_dsc(matches, json_entries):
 # sort entries into sorted pages
 def sort_browse_entries_into_list(json_entries):
     # group into pages
-    pages = defaultdict(list)
+    pages = {}
     for entry in json_entries.values():
-        pages[entry['page']].append(entry)
+        page_name = entry['page']
+        if page_name not in pages:
+            pages[page_name] = []
+        pages[page_name].append(entry)
 
     # sort the entries within each page
-    sorted_matches = sorted(
-        page.items(),
-        key=lambda item: (split_page_key(json_entries[item[0]]['page']))
+    sorted_pages = sorted(
+        pages.items(),
+        key=lambda item: (split_page_key(item[0]))
     )
 
     return [

--- a/search-app/back-end/resources/python/sort_methods.py
+++ b/search-app/back-end/resources/python/sort_methods.py
@@ -137,3 +137,21 @@ def sort_chronological_dsc(matches, json_entries):
         reverse=True
     )
     return dict(sorted_matches)
+
+# sort entries into sorted pages
+def sort_browse_entries_into_list(json_entries):
+    # group into pages
+    pages = defaultdict(list)
+    for entry in json_entries.values():
+        pages[entry['page']].append(entry)
+
+    # sort the entries within each page
+    sorted_matches = sorted(
+        page.items(),
+        key=lambda item: (split_page_key(json_entries[item[0]]['page']))
+    )
+
+    return [
+        {"page": page_name, "records": entries}
+        for page_name, entries in sorted_pages
+    ]

--- a/search-app/back-end/resources/python/sort_methods.py
+++ b/search-app/back-end/resources/python/sort_methods.py
@@ -41,7 +41,6 @@ return example:
 """
 # considers page numbers with letters as well ex. 130A
 def split_page_key(page):
-    print(page)
     match = re.match(r'^(\d+)([a-zA-Z]?)$', str(page))
     number = int(match.group(1))
     letter = match.group(2).lower() if match.group(2) else ''

--- a/search-app/back-end/resources/python/test-browse.py
+++ b/search-app/back-end/resources/python/test-browse.py
@@ -1,0 +1,29 @@
+from Search import Search
+from pathlib import Path
+import sort_methods
+import json
+from browse_search import BrowseSearch
+
+json_filepath = Path(__file__).resolve().parent.parent / 'json' / 'entries.json'
+json_entries = []
+with open(json_filepath, 'r') as json_file:
+    json_entries = json.load(json_file)
+
+
+params = {
+    'vol': '1'
+}
+
+
+print('searching')
+search_obj = BrowseSearch(params, json_entries)
+search_obj.start()
+matches = search_obj.get_matches()
+print('number of entries matched: '+str(len(matches)))
+if matches != None:
+    json.dumps(matches, indent=4)
+    print(json.dumps(matches, indent=4))
+
+    # for page in matches:
+    #     for 
+        

--- a/search-app/back-end/routes/web.php
+++ b/search-app/back-end/routes/web.php
@@ -17,10 +17,9 @@ Route::prefix('/api')->group(function () {
     Route::get('/test-request', [TestController::class, 'test']);
     Route::get('/search', [SearchController::class, 'search']);
     Route::get('/xquery', [SearchController::class, 'runXQuery']);
+    Route::get('/rawEntry', [SearchController::class, 'getRawEntry']);
 
-    Route::get('/volumes', [RecordController::class, 'getVolumes']);
     Route::get('/records', [RecordController::class, 'getRecords']);
-    Route::get('/records/{id}/xml', [RecordController::class, 'getXml']);
     
 });
 

--- a/search-app/back-end/routes/web.php
+++ b/search-app/back-end/routes/web.php
@@ -4,6 +4,7 @@ use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\RouteController;
 use App\Http\Controllers\SearchController;
 use App\Http\Controllers\TestController;
+use App\Http\Controllers\RecordController;
 
 
 /*
@@ -15,4 +16,8 @@ Route::prefix('/api')->group(function () {
     Route::get('/test-request', [TestController::class, 'test']);
     Route::get('/search', [SearchController::class, 'search']);
     Route::get('/xquery', [SearchController::class, 'runXQuery']);
+
+    Route::get('/volumes', [RecordController::class, 'getVolumes']);
+    Route::get('/records', [RecordController::class, 'getRecords']);
+    Route::get('/records/{id}/xml', [RecordController::class, 'getXml']);
 });

--- a/search-app/back-end/routes/web.php
+++ b/search-app/back-end/routes/web.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\RouteController;
 use App\Http\Controllers\SearchController;
 use App\Http\Controllers\TestController;
 use App\Http\Controllers\RecordController;
+use Illuminate\Support\Facades\File;
 
 
 /*
@@ -20,4 +21,9 @@ Route::prefix('/api')->group(function () {
     Route::get('/volumes', [RecordController::class, 'getVolumes']);
     Route::get('/records', [RecordController::class, 'getRecords']);
     Route::get('/records/{id}/xml', [RecordController::class, 'getXml']);
+    
 });
+
+Route::get('/{any}', function () {
+    return File::get(public_path('index.html'));
+})->where('any', '.*');

--- a/search-app/back-end/vite.config.js
+++ b/search-app/back-end/vite.config.js
@@ -1,5 +1,7 @@
 import { defineConfig } from "vite";
 import laravel from "laravel-vite-plugin";
+import vue from "@vitejs/plugin-vue";
+import path from "path";
 
 export default defineConfig({
     plugins: [
@@ -7,5 +9,11 @@ export default defineConfig({
             input: ["resources/css/app.css", "resources/js/app.js"],
             refresh: true,
         }),
+        vue(), 
     ],
+    resolve: {
+        alias: {
+            '@': path.resolve(__dirname, 'src'), // adjust if your src is elsewhere
+        },
+    },
 });

--- a/search-app/front-end/src/components/BrowseContent.vue
+++ b/search-app/front-end/src/components/BrowseContent.vue
@@ -93,7 +93,6 @@
 
 <script>
 import pageImage from '@/assets/images/try_one.jpeg';
-import { inject } from 'vue';
 import api from '@/services/api';
 
 export default {

--- a/search-app/front-end/src/components/BrowseContent.vue
+++ b/search-app/front-end/src/components/BrowseContent.vue
@@ -207,7 +207,8 @@ export default {
     window.addEventListener('resize', this.checkDeviceSize);
 
     await this.loadVolumes();
-    await this.loadRecords();
+    //await this.loadRecords();
+    this.handleVolumeChange();
   },
   unmounted() {
     window.removeEventListener('resize', this.checkDeviceSize);

--- a/search-app/front-end/src/components/BrowseContent.vue
+++ b/search-app/front-end/src/components/BrowseContent.vue
@@ -198,7 +198,7 @@ onMounted(() => {
 
               <input type="string" v-model="browseState.currentPage" min="1" :max="browseState.pages.length" @keyup.enter="goToSpecificPage"/>
               <span>of {{ browseState.pages.length }}</span>
-              <button class="page-go-btn" @click="goToSpecificPage">Go</button>
+              <!-- <button class="page-go-btn" @click="goToSpecificPage">Go</button> -->
 
               <button class="nav-btn" @click="goToNextPage" :disabled="browseState.currentPage >= browseState.pages.length">&gt;</button>
               <button class="nav-btn" @click="goToLastPage">&gt;&gt;</button>

--- a/search-app/front-end/src/components/BrowseContent.vue
+++ b/search-app/front-end/src/components/BrowseContent.vue
@@ -1,99 +1,71 @@
 <template>
-  <div class="notification-banner">
-    <div class="notification-content">
-      <div class="notification-icon">ℹ️</div>
-      <div class="notification-text">
-        <strong>Please Note:</strong> While the Browse page UI is fully functional, it currently displays a placeholder record only. The record fetching functionality is still a work in progress and will be implemented in a future update.
-      </div>
-    </div>
-  </div>
-
-  <div class="container-browser">
-    <div class="volume-nav">
-      <select data-tooltip="Select the Preferred Volume" class="volume-select" v-model="currentVolume" @change="handleVolumeChange">
-        <option v-for="(pageCount, volId) in volumes" :key="volId" :value="Number(volId)">
-          Volume {{ volId }}
-        </option>
-      </select>
-    </div>
-
-    <div class="split-view">
-      <div class="image-viewer" ref="imageViewer">
-        <img 
-          :src="pageImage" 
-          alt="Page Image" 
-          class="page-image" 
-          @touchstart="handleTouchStart"
-          @touchmove="handleTouchMove"
-          @touchend="handleTouchEnd"
-          @mousemove="handleZoom" 
-          @click="toggleZoom"
-          @mouseleave="resetZoom"
-          ref="pageImageRef"
-          :style="imageStyle"
-        />
-        <div v-if="isMobile || smallScreen" class="mobile-zoom-indicator" :class="{ active: isZooming }">
-          <span v-if="isZooming">Click or double click to exit zoom</span>
-          <span v-else>Click or double click to zoom</span>
+  <div class="browse-page">
+    <main class="content">
+      <div class="notification-banner">
+        <div class="notification-content">
+          <div class="notification-icon">ℹ️</div>
+          <div class="notification-text">
+            <strong>Please Note:</strong> While the Browse page UI is fully functional, it currently displays a placeholder record only. The record fetching functionality is still a work in progress and will be implemented in a future update.
+          </div>
         </div>
       </div>
 
-      <div class="records-container">
-        <div class="page-navigation">
-          <button class="nav-btn" @click="goToFirstPage">&lt;&lt;</button>
-          <button class="nav-btn" @click="goToPrevPage" :disabled="currentPage <= 1">&lt;</button>
+      <div class="container-browser">
+        <div class="volume-nav">
+          <select class="volume-select" v-model="currentVolume" @change="handleVolumeChange">
+            <option v-for="(pageCount, volId) in volumes" :key="volId" :value="Number(volId)">
+              Volume {{ volId }}
+            </option>
+          </select>
+        </div>
 
-          <div class="page-number-search">
-            <span class="page-label">Page</span>
-            <input type="number" v-model.number="currentPage" class="page-number-input" min="1" :max="volumes[currentVolume]" @keyup.enter="goToSpecificPage" />
-            <span class="page-total">of {{ volumes[currentVolume] }}</span>
-            <button class="page-go-btn" @click="goToSpecificPage">Go</button>
+        <div class="split-view">
+          <div class="image-viewer" ref="imageViewer">
+            <img
+              :src="pageImage"
+              alt="Page Image"
+              class="page-image"
+              @mousemove="handleZoom"
+              @click="toggleZoom"
+              @mouseleave="resetZoom"
+              ref="pageImageRef"
+              :style="imageStyle"
+            />
           </div>
 
-          <button class="nav-btn" @click="goToNextPage" :disabled="currentPage >= volumes[currentVolume]">&gt;</button>
-          <button class="nav-btn" @click="goToLastPage">&gt;&gt;</button>
-        </div>
+          <div class="records-container">
+            <div class="page-navigation">
+              <button class="nav-btn" @click="goToFirstPage">&lt;&lt;</button>
+              <button class="nav-btn" @click="goToPrevPage" :disabled="currentPage <= 1">&lt;</button>
 
-        <div class="records">
-          <div v-for="record in records" :key="record.id" class="record-item">
-            <div class="record-header">
-              <div class="record-field"><span class="record-label">ID:</span><span>{{ record.id }}</span></div>
-              <div class="record-field"><span class="record-label">Date:</span><span>{{ record.date }}</span></div>
-              <div class="record-field"><span class="record-label">Language:</span><span>{{ record.language }}</span></div>
+              <input type="number" v-model.number="currentPage" min="1" :max="volumes[currentVolume]" @keyup.enter="goToSpecificPage" />
+              <span>of {{ volumes[currentVolume] }}</span>
+              <button class="page-go-btn" @click="goToSpecificPage">Go</button>
+
+              <button class="nav-btn" @click="goToNextPage" :disabled="currentPage >= volumes[currentVolume]">&gt;</button>
+              <button class="nav-btn" @click="goToLastPage">&gt;&gt;</button>
             </div>
-            <div class="record-content">{{ record.content }}</div>
-            <div class="record-actions">
-              <button class="xml-btn" @click="viewXML(record.id)">XML</button>
-              <div class="checkbox-container">
-                <input type="checkbox" :id="`record-${record.id}-checkbox`" :checked="isRecordSelected(record.id)" @change="toggleRecordSelection(record)" />
-                <label :for="`record-${record.id}-checkbox`">Add to selected</label>
+
+            <div class="records">
+              <div v-for="record in records" :key="record.id" class="record-item">
+                <div class="record-header">
+                  <div>ID: {{ record.id }}</div>
+                  <div>Date: {{ record.date }}</div>
+                  <div>Language: {{ record.language }}</div>
+                </div>
+                <div class="record-content">{{ record.content }}</div>
               </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
-
-    <div v-if="showXmlModal" class="xml-modal-overlay">
-      <div class="xml-modal">
-        <div class="xml-modal-header">
-          <h3>XML Content: {{ currentXmlRecordId }}</h3>
-          <button class="close-btn" @click="closeXmlModal">&times;</button>
-        </div>
-        <div class="xml-modal-body">
-          <pre class="xml-content">{{ currentXmlContent }}</pre>
-        </div>
-        <div class="xml-modal-footer">
-          <button class="copy-btn" @click="copyXmlContent">Copy to Clipboard</button>
-        </div>
-      </div>
-    </div>
+    </main>
   </div>
 </template>
 
 <script>
 import pageImage from '@/assets/images/try_one.jpeg';
-import api from '@/services/api';
+import api from '@/services/api'; // ✅ Ensure this file exists and uses: `export default axios.create(...)`
 
 export default {
   data() {
@@ -103,70 +75,46 @@ export default {
       currentPage: 1,
       volumes: {},
       records: [],
-      showXmlModal: false,
-      currentXmlRecordId: '',
-      currentXmlContent: '',
       zoomScale: 2.5,
       isZooming: false,
       transformOrigin: '0% 0%',
-      isMobile: false,
-      smallScreen: false,
-      lastTapTime: 0,
-      doubleTapDelay: 300,
-      mouseX: 0,
-      mouseY: 0,
     };
   },
-  inject: ['selectedRecords'],
   computed: {
     imageStyle() {
       if (!this.isZooming) {
-        return {
-          transform: 'scale(1)',
-          transformOrigin: 'center center'
-        };
+        return { transform: 'scale(1)' };
       }
       return {
         transform: `scale(${this.zoomScale})`,
         transformOrigin: this.transformOrigin,
-        transition: 'transform 0.1s ease-out'
       };
-    }
+    },
   },
   mounted() {
-    this.checkDeviceSize();
-    window.addEventListener('resize', this.checkDeviceSize);
     this.loadVolumes();
     this.loadRecords();
   },
-  unmounted() {
-    window.removeEventListener('resize', this.checkDeviceSize);
-  },
   methods: {
-    isRecordSelected(id) {
-      return this.selectedRecords.value.some(r => r.id === id);
-    },
-    toggleRecordSelection(record) {
-      const index = this.selectedRecords.value.findIndex(r => r.id === record.id);
-      if (index === -1) this.selectedRecords.value.push({ ...record });
-      else this.selectedRecords.value.splice(index, 1);
-    },
     async loadVolumes() {
       try {
-        const res = await api.get('/volumes');
-        this.volumes = res.data;
-      } catch (e) {
-        console.error('Volumes error:', e);
+        const response = await api.get('/volumes');
+        this.volumes = response.data;
+      } catch (error) {
+        console.error('Failed to fetch volumes:', error);
       }
     },
     async loadRecords() {
       try {
-        const res = await api.get('/records', {
-          params: { volume: this.currentVolume, page: this.currentPage }
+        const response = await api.get('/records', {
+          params: {
+            volume: this.currentVolume,
+            page: this.currentPage,
+          },
         });
-        this.records = res.data.records;
-      } catch (e) {
-        console.error('Records error:', e);
+        this.records = response.data.records;
+      } catch (error) {
+        console.error('Failed to fetch records:', error);
       }
     },
     handleVolumeChange() {
@@ -199,70 +147,30 @@ export default {
       else if (this.currentPage > max) this.currentPage = max;
       this.loadRecords();
     },
-    async viewXML(recordId) {
-      this.currentXmlRecordId = recordId;
-      try {
-        const res = await api.get(`/records/${recordId}/xml`);
-        this.currentXmlContent = res.data.xml || 'No XML content found.';
-      } catch (e) {
-        console.error('XML error:', e);
-        this.currentXmlContent = 'Error fetching XML content.';
-      }
-      this.showXmlModal = true;
-    },
-    closeXmlModal() {
-      this.showXmlModal = false;
-    },
-    copyXmlContent() {
-      navigator.clipboard.writeText(this.currentXmlContent)
-        .then(() => alert('Copied!'))
-        .catch(() => alert('Copy failed.'));
-    },
-    checkDeviceSize() {
-      this.isMobile = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
-      this.smallScreen = window.innerWidth <= 768;
-    },
-    handleZoom(e) {
+    handleZoom(event) {
       const rect = this.$refs.pageImageRef.getBoundingClientRect();
-      const x = ((e.clientX - rect.left) / rect.width) * 100;
-      const y = ((e.clientY - rect.top) / rect.height) * 100;
+      const x = ((event.clientX - rect.left) / rect.width) * 100;
+      const y = ((event.clientY - rect.top) / rect.height) * 100;
       this.transformOrigin = `${x}% ${y}%`;
-      if (!this.smallScreen && !this.isMobile) this.isZooming = true;
+      this.isZooming = true;
     },
-    toggleZoom(e) {
+    toggleZoom(event) {
       const rect = this.$refs.pageImageRef.getBoundingClientRect();
-      const x = ((e.clientX - rect.left) / rect.width) * 100;
-      const y = ((e.clientY - rect.top) / rect.height) * 100;
+      const x = ((event.clientX - rect.left) / rect.width) * 100;
+      const y = ((event.clientY - rect.top) / rect.height) * 100;
       this.transformOrigin = `${x}% ${y}%`;
       this.isZooming = !this.isZooming;
     },
-    handleTouchStart(e) {
-      if (!this.$refs.pageImageRef) return;
-      e.preventDefault();
-      if (e.touches.length === 1) {
-        const touch = e.touches[0];
-        const rect = this.$refs.pageImageRef.getBoundingClientRect();
-        const x = ((touch.clientX - rect.left) / rect.width) * 100;
-        const y = ((touch.clientY - rect.top) / rect.height) * 100;
-        this.transformOrigin = `${x}% ${y}%`;
-        const now = new Date().getTime();
-        if (now - this.lastTapTime < this.doubleTapDelay) this.isZooming = !this.isZooming;
-        this.lastTapTime = now;
-      }
-    },
-    handleTouchMove(e) {
-      e.preventDefault();
-      if (!this.isZooming) return;
-      const touch = e.touches[0];
-      const rect = this.$refs.pageImageRef.getBoundingClientRect();
-      const x = ((touch.clientX - rect.left) / rect.width) * 100;
-      const y = ((touch.clientY - rect.top) / rect.height) * 100;
-      this.transformOrigin = `${x}% ${y}%`;
-    },
-    handleTouchEnd() {},
     resetZoom() {
-      if (!this.smallScreen && !this.isMobile) this.isZooming = false;
-    }
-  }
+      this.isZooming = false;
+    },
+  },
 };
 </script>
+
+<style scoped>
+/* Add minimal styles to make it visible if not styled yet */
+.browse-page {
+  padding: 1rem;
+}
+</style>

--- a/search-app/front-end/src/components/BrowseContent.vue
+++ b/search-app/front-end/src/components/BrowseContent.vue
@@ -26,8 +26,6 @@ function onChangeVolume(){
   loadRecordsForSingleVolume(browseState.currentVolume);
 }
 
-
-
 const loadRecordsForSingleVolume = async (volume) => {
   browseState.pagesLoading = true;
   try {
@@ -68,6 +66,11 @@ const goToSpecificPage = () => {
 
 const currentRecords = computed(() => {
   return browseState.pages?.[browseState.currentPage - 1]?.records || [];
+});
+
+const currentPageName = computed(() => {
+  console.log(browseState.pages?.[browseState.currentPage - 1]?.page || "");
+  return browseState.pages?.[browseState.currentPage - 1]?.page || "";
 });
 
 // image stuff
@@ -163,15 +166,6 @@ onMounted(() => {
 <template>
   <div class="browse-page">
     <main class="content">
-      <!-- <div class="notification-banner">
-        <div class="notification-content">
-          <div class="notification-icon">ℹ️</div>
-          <div class="notification-text">
-            <strong>Please Note:</strong> While the Browse page UI is fully functional, it currently displays a placeholder record only. The record fetching functionality is still a work in progress and will be implemented in a future update.
-          </div>
-        </div>
-      </div> -->
-
       <div class="container-browser">
         <div class="volume-nav">
           <select class="volume-select" v-model="browseState.currentVolume" @change="onChangeVolume" :disabled="browseState.pagesLoading">
@@ -180,6 +174,8 @@ onMounted(() => {
             </option>
           </select>
         </div>
+
+        <div>Volume: {{ browseState.currentVolume }}<span v-if="currentPageName != ''">, Page: {{ currentPageName }}</span></div>
 
         <div class="split-view">
           <div class="image-viewer" ref="imageViewer">

--- a/search-app/front-end/src/components/BrowseContent.vue
+++ b/search-app/front-end/src/components/BrowseContent.vue
@@ -124,25 +124,18 @@ export default {
       pageImage,
       currentVolume: 1,
       currentPage: 1,
-      volumes: {
-        1: 20,
-        2: 15,
-        4: 25,
-        5: 18,
-        6: 22,
-        7: 16,
-        8: 19
-      },
+      volumes: {},
       records: [],
       
       // XML Modal properties
       showXmlModal: false,
       currentXmlRecordId: '',
       currentXmlContent: '',
-      xmlData: {
-        'ARO-1-0001-01': '<div type="heading" xml:id="ARO-1-0001-01" xml:lang="lat">\n  <head>Processus Curiarum Balliuorum Isti Sunt</head>\n  <p><lb break="yes"/>qui incipiunt die lune  proximo  post festum beati michaelis archangeli Anno<lb break="yes"/>Domini Millesimo  ccc<hi rend="superscript">mo</hi>  nonogesimo  Octauo .</p>\n</div>',
-        'ARO-1-0001-02': '<div type="heading" xml:id="ARO-1-0001-02" xml:lang="lat">\n  <head>Quo die Willelmus de Camera pater</head>\n  <p><lb break="yes"/>cum pertinentiis quibuscumque...</p>\n</div>'
-      },
+      //xmlData: {
+      //  'ARO-1-0001-01': '<div type="heading" xml:id="ARO-1-0001-01" xml:lang="lat">\n  <head>Processus Curiarum Balliuorum Isti Sunt</head>\n  <p><lb break="yes"/>qui incipiunt die lune  proximo  post festum beati michaelis archangeli Anno<lb break="yes"/>Domini Millesimo  ccc<hi rend="superscript">mo</hi>  nonogesimo  Octauo .</p>\n</div>',
+      //  'ARO-1-0001-02': '<div type="heading" xml:id="ARO-1-0001-02" xml:lang="lat">\n  <head>Quo die Willelmus de Camera pater</head>\n  <p><lb break="yes"/>cum pertinentiis quibuscumque...</p>\n</div>'
+     // },
+
       // Zoom properties
       zoomScale: 2.5, // Increased zoom scale for better visibility
       isZooming: false,
@@ -282,12 +275,18 @@ export default {
       
       this.loadRecords();
     },
-    viewXML(recordId) {
+    async viewXML(recordId) {
       this.currentXmlRecordId = recordId;
-      this.currentXmlContent = this.xmlData[recordId] || 'XML content not found';
+      try {
+        const response = await axios.get(`/api/records/${recordId}/xml`);
+        this.currentXmlContent = response.data.xml || 'No XML content found.';
+      } catch (error) {
+        console.error('Failed to fetch XML:', error);
+        this.currentXmlContent = 'Error fetching XML content.';
+      }
       this.showXmlModal = true;
-      console.log(`Viewing XML for record ${recordId}`);
     },
+
     closeXmlModal() {
       this.showXmlModal = false;
     },

--- a/search-app/front-end/src/components/BrowseContent.vue
+++ b/search-app/front-end/src/components/BrowseContent.vue
@@ -1,4 +1,6 @@
-import axios from 'axios'
+
+import api from '@/services/api';
+
 <template>
   <div class="notification-banner">
     <div class="notification-content">
@@ -118,6 +120,7 @@ import axios from 'axios'
 <script>
 import pageImage from '@/assets/images/try_one.jpeg';
 import { inject, ref, computed, onMounted } from 'vue';
+import api from '../../services/api';
 
 export default {
   data() {
@@ -220,7 +223,7 @@ export default {
     },
     async loadVolumes() {
     try {
-      const response = await axios.get('/api/volumes');
+      const response = await api.get('/volumes');
       this.volumes = response.data;
     } catch (error) {
       console.error('Failed to fetch volumes:', error);
@@ -228,7 +231,7 @@ export default {
     },
     async loadRecords() {
     try {
-      const response = await axios.get('/api/records', {
+      const response = await api.get(`/records`, {
         params: {
           volume: this.currentVolume,
           page: this.currentPage
@@ -279,7 +282,7 @@ export default {
     async viewXML(recordId) {
       this.currentXmlRecordId = recordId;
       try {
-        const response = await axios.get(`/api/records/${recordId}/xml`);
+        const response = await api.get(`/records/${recordId}/xml`);
         this.currentXmlContent = response.data.xml || 'No XML content found.';
       } catch (error) {
         console.error('Failed to fetch XML:', error);

--- a/search-app/front-end/src/components/BrowseContent.vue
+++ b/search-app/front-end/src/components/BrowseContent.vue
@@ -300,11 +300,6 @@ export default {
           alert('Failed to copy XML content. Please try again.');
         });
     },
-    loadRecords() {
-      console.log(`Loading records for Volume ${this.currentVolume}, Page ${this.currentPage}`);
-      // Here you would typically fetch records from an API
-      // For now we'll just use the static records in data()
-    },
     
     // Zoom methods that work for both touch and mouse
     handleZoom(event) {

--- a/search-app/front-end/src/components/BrowseContent.vue
+++ b/search-app/front-end/src/components/BrowseContent.vue
@@ -7,6 +7,7 @@
       </div>
     </div>
   </div>
+
   <div class="container-browser">
     <div class="volume-nav">
       <select data-tooltip="Select the Preferred Volume" class="volume-select" v-model="currentVolume" @change="handleVolumeChange">
@@ -15,7 +16,7 @@
         </option>
       </select>
     </div>
-    
+
     <div class="split-view">
       <div class="image-viewer" ref="imageViewer">
         <img 
@@ -36,58 +37,35 @@
           <span v-else>Click or double click to zoom</span>
         </div>
       </div>
-      
+
       <div class="records-container">
         <div class="page-navigation">
-          <button data-tooltip="Click Here to go to the First Page of the Volume" class="nav-btn" @click="goToFirstPage">&lt;&lt;</button>
-          <button data-tooltip="Click here for the previous Page" class="nav-btn" @click="goToPrevPage" :disabled="currentPage <= 1">&lt;</button>
-          
+          <button class="nav-btn" @click="goToFirstPage">&lt;&lt;</button>
+          <button class="nav-btn" @click="goToPrevPage" :disabled="currentPage <= 1">&lt;</button>
+
           <div class="page-number-search">
             <span class="page-label">Page</span>
-            <input 
-              type="number" 
-              v-model.number="currentPage" 
-              class="page-number-input" 
-              min="1" 
-              :max="volumes[currentVolume]"
-              @keyup.enter="goToSpecificPage"
-            />
+            <input type="number" v-model.number="currentPage" class="page-number-input" min="1" :max="volumes[currentVolume]" @keyup.enter="goToSpecificPage" />
             <span class="page-total">of {{ volumes[currentVolume] }}</span>
-            <button class="page-go-btn" @click="goToSpecificPage" data-tooltip="Go to specified page">Go</button>
+            <button class="page-go-btn" @click="goToSpecificPage">Go</button>
           </div>
-          
-          <button data-tooltip="Click Here for the Next Page" class="nav-btn" @click="goToNextPage" :disabled="currentPage >= volumes[currentVolume]">&gt;</button>
-          <button data-tooltip="Click here to go the Last Page of the Volume" class="nav-btn" @click="goToLastPage">&gt;&gt;</button>
+
+          <button class="nav-btn" @click="goToNextPage" :disabled="currentPage >= volumes[currentVolume]">&gt;</button>
+          <button class="nav-btn" @click="goToLastPage">&gt;&gt;</button>
         </div>
-        
+
         <div class="records">
           <div v-for="record in records" :key="record.id" class="record-item">
             <div class="record-header">
-              <div class="record-field">
-                <span class="record-label">ID:</span>
-                <span>{{ record.id }}</span>
-              </div>
-              <div class="record-field">
-                <span class="record-label">Date:</span>
-                <span>{{ record.date }}</span>
-              </div>
-              <div class="record-field">
-                <span class="record-label">Language:</span>
-                <span>{{ record.language }}</span>
-              </div>
+              <div class="record-field"><span class="record-label">ID:</span><span>{{ record.id }}</span></div>
+              <div class="record-field"><span class="record-label">Date:</span><span>{{ record.date }}</span></div>
+              <div class="record-field"><span class="record-label">Language:</span><span>{{ record.language }}</span></div>
             </div>
-            <div class="record-content">
-              {{ record.content }}
-            </div>
+            <div class="record-content">{{ record.content }}</div>
             <div class="record-actions">
-              <button data-tooltip="Click Here to See the XML Format of the Content" class="xml-btn" @click="viewXML(record.id)">XML</button>
-              <div data-tooltip="Click Here to Add the Content to the Selected Page" class="checkbox-container">
-                <input 
-                  type="checkbox" 
-                  :id="`record-${record.id}-checkbox`" 
-                  :checked="isRecordSelected(record.id)"
-                  @change="toggleRecordSelection(record)"
-                >
+              <button class="xml-btn" @click="viewXML(record.id)">XML</button>
+              <div class="checkbox-container">
+                <input type="checkbox" :id="`record-${record.id}-checkbox`" :checked="isRecordSelected(record.id)" @change="toggleRecordSelection(record)" />
                 <label :for="`record-${record.id}-checkbox`">Add to selected</label>
               </div>
             </div>
@@ -95,8 +73,7 @@
         </div>
       </div>
     </div>
-    
-    <!-- XML Modal -->
+
     <div v-if="showXmlModal" class="xml-modal-overlay">
       <div class="xml-modal">
         <div class="xml-modal-header">
@@ -116,7 +93,7 @@
 
 <script>
 import pageImage from '@/assets/images/try_one.jpeg';
-import { inject, ref, computed, onMounted } from 'vue';
+import { inject } from 'vue';
 import api from '@/services/api';
 
 export default {
@@ -127,66 +104,25 @@ export default {
       currentPage: 1,
       volumes: {},
       records: [],
-      
-      // XML Modal properties
       showXmlModal: false,
       currentXmlRecordId: '',
       currentXmlContent: '',
-      //xmlData: {
-      //  'ARO-1-0001-01': '<div type="heading" xml:id="ARO-1-0001-01" xml:lang="lat">\n  <head>Processus Curiarum Balliuorum Isti Sunt</head>\n  <p><lb break="yes"/>qui incipiunt die lune  proximo  post festum beati michaelis archangeli Anno<lb break="yes"/>Domini Millesimo  ccc<hi rend="superscript">mo</hi>  nonogesimo  Octauo .</p>\n</div>',
-      //  'ARO-1-0001-02': '<div type="heading" xml:id="ARO-1-0001-02" xml:lang="lat">\n  <head>Quo die Willelmus de Camera pater</head>\n  <p><lb break="yes"/>cum pertinentiis quibuscumque...</p>\n</div>'
-     // },
-
-      // Zoom properties
-      zoomScale: 2.5, // Increased zoom scale for better visibility
+      zoomScale: 2.5,
       isZooming: false,
       zoomX: 0,
       zoomY: 0,
       transformOrigin: '0% 0%',
-      // Device specific properties
       isMobile: false,
       smallScreen: false,
       lastTouchX: 0,
       lastTouchY: 0,
       lastTapTime: 0,
-      doubleTapDelay: 300, // milliseconds
-      // Track mouse position for consistent zooming
+      doubleTapDelay: 300,
       mouseX: 0,
       mouseY: 0
-    }
-  },
-  setup() {
-    // Inject the shared selectedRecords state
-    const selectedRecords = inject('selectedRecords', ref([]));
-    const pageImageRef = ref(null);
-    const imageViewer = ref(null);
-    
-    // Check if a record is selected
-    const isRecordSelected = (recordId) => {
-      return selectedRecords.value.some(record => record.id === recordId);
-    };
-    
-    // Toggle record selection
-    const toggleRecordSelection = (record) => {
-      const index = selectedRecords.value.findIndex(r => r.id === record.id);
-      
-      if (index === -1) {
-        // Add to selected records if not already there
-        selectedRecords.value.push({ ...record });
-      } else {
-        // Remove from selected records
-        selectedRecords.value.splice(index, 1);
-      }
-    };
-    
-    return {
-      selectedRecords,
-      isRecordSelected,
-      toggleRecordSelection,
-      pageImageRef,
-      imageViewer
     };
   },
+  inject: ['selectedRecords'],
   computed: {
     imageStyle() {
       if (!this.isZooming) {
@@ -195,7 +131,6 @@ export default {
           transformOrigin: 'center center'
         };
       }
-      
       return {
         transform: `scale(${this.zoomScale})`,
         transformOrigin: this.transformOrigin,
@@ -203,46 +138,51 @@ export default {
       };
     }
   },
-  async mounted() {
+  mounted() {
     this.checkDeviceSize();
     window.addEventListener('resize', this.checkDeviceSize);
-
-    await this.loadVolumes();
-    await this.loadRecords();
+    this.loadVolumes();
+    this.loadRecords();
   },
   unmounted() {
     window.removeEventListener('resize', this.checkDeviceSize);
   },
   methods: {
-    checkDeviceSize() {
-      this.isMobile = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
-      this.smallScreen = window.innerWidth <= 768;
+    isRecordSelected(recordId) {
+      return this.selectedRecords.value.some(record => record.id === recordId);
+    },
+    toggleRecordSelection(record) {
+      const index = this.selectedRecords.value.findIndex(r => r.id === record.id);
+      if (index === -1) {
+        this.selectedRecords.value.push({ ...record });
+      } else {
+        this.selectedRecords.value.splice(index, 1);
+      }
     },
     async loadVolumes() {
-    try {
-      const response = await api.get('/volumes');
-      this.volumes = response.data;
-    } catch (error) {
-      console.error('Failed to fetch volumes:', error);
-    }
+      try {
+        const response = await api.get('/volumes');
+        this.volumes = response.data;
+      } catch (error) {
+        console.error('Failed to fetch volumes:', error);
+      }
     },
     async loadRecords() {
-    try {
-      const response = await api.get(`/records`, {
-        params: {
-          volume: this.currentVolume,
-          page: this.currentPage
-        }
-      });
-      this.records = response.data.records;
-    } catch (error) {
-      console.error('Failed to fetch records:', error);
-    }
+      try {
+        const response = await api.get('/records', {
+          params: {
+            volume: this.currentVolume,
+            page: this.currentPage
+          }
+        });
+        this.records = response.data.records;
+      } catch (error) {
+        console.error('Failed to fetch records:', error);
+      }
     },
     handleVolumeChange() {
       this.currentPage = 1;
       this.loadRecords();
-      console.log(`Changed to Volume ${this.currentVolume}, Page ${this.currentPage}`);
     },
     goToFirstPage() {
       this.currentPage = 1;
@@ -265,15 +205,9 @@ export default {
       this.loadRecords();
     },
     goToSpecificPage() {
-      // Ensure the page is within valid range
       const maxPage = this.volumes[this.currentVolume];
-      
-      if (this.currentPage < 1) {
-        this.currentPage = 1;
-      } else if (this.currentPage > maxPage) {
-        this.currentPage = maxPage;
-      }
-      
+      if (this.currentPage < 1) this.currentPage = 1;
+      else if (this.currentPage > maxPage) this.currentPage = maxPage;
       this.loadRecords();
     },
     async viewXML(recordId) {
@@ -287,123 +221,70 @@ export default {
       }
       this.showXmlModal = true;
     },
-
     closeXmlModal() {
       this.showXmlModal = false;
     },
     copyXmlContent() {
       navigator.clipboard.writeText(this.currentXmlContent)
-        .then(() => {
-          alert('XML content copied to clipboard!');
-        })
+        .then(() => alert('XML content copied to clipboard!'))
         .catch(err => {
-          console.error('Failed to copy: ', err);
+          console.error('Failed to copy:', err);
           alert('Failed to copy XML content. Please try again.');
         });
     },
-    
-    // Zoom methods that work for both touch and mouse
+    checkDeviceSize() {
+      this.isMobile = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
+      this.smallScreen = window.innerWidth <= 768;
+    },
     handleZoom(event) {
-      if (!this.$refs.pageImageRef) return;
-      
       const rect = this.$refs.pageImageRef.getBoundingClientRect();
-      
-      // Store mouse position for use in toggleZoom
       this.mouseX = event.clientX;
       this.mouseY = event.clientY;
-      
       const x = ((event.clientX - rect.left) / rect.width) * 100;
       const y = ((event.clientY - rect.top) / rect.height) * 100;
-      
       this.transformOrigin = `${x}% ${y}%`;
-      
-      // Only auto-zoom on mousemove if not in small screen mode
       if (!this.smallScreen && !this.isMobile) {
         this.isZooming = true;
       }
     },
-    
-    // Toggle zoom on click (for both small screens and mobile)
     toggleZoom(event) {
-      if (!this.$refs.pageImageRef) return;
-      
-      // If we're in small screen mode, toggle zoom state
-      if (this.smallScreen || this.isMobile) {
-        if (this.isZooming) {
-          // If already zooming, turn it off
-          this.isZooming = false;
-        } else {
-          // If not zooming, use the current mouse position as focal point
-          const rect = this.$refs.pageImageRef.getBoundingClientRect();
-          const x = ((event.clientX - rect.left) / rect.width) * 100;
-          const y = ((event.clientY - rect.top) / rect.height) * 100;
-          
-          this.transformOrigin = `${x}% ${y}%`;
-          this.isZooming = true;
-        }
-      }
+      const rect = this.$refs.pageImageRef.getBoundingClientRect();
+      const x = ((event.clientX - rect.left) / rect.width) * 100;
+      const y = ((event.clientY - rect.top) / rect.height) * 100;
+      this.transformOrigin = `${x}% ${y}%`;
+      this.isZooming = !this.isZooming;
     },
-    
-    // Mobile touch methods
     handleTouchStart(event) {
       if (!this.$refs.pageImageRef) return;
-      
-      // Prevent default behavior to avoid page scrolling when zooming
       event.preventDefault();
-      
-      // Handle single touch (positioning)
       if (event.touches.length === 1) {
         const touch = event.touches[0];
-        this.lastTouchX = touch.clientX;
-        this.lastTouchY = touch.clientY;
-        
         const rect = this.$refs.pageImageRef.getBoundingClientRect();
         const x = ((touch.clientX - rect.left) / rect.width) * 100;
         const y = ((touch.clientY - rect.top) / rect.height) * 100;
-        
         this.transformOrigin = `${x}% ${y}%`;
-        
-        // Toggle zoom on single tap
         const now = new Date().getTime();
-        const timeSince = now - this.lastTapTime;
-        
-        if (timeSince < this.doubleTapDelay && timeSince > 0) {
-          // Double tap - toggle zoom
+        if (now - this.lastTapTime < this.doubleTapDelay) {
           this.isZooming = !this.isZooming;
         }
-        
         this.lastTapTime = now;
       }
     },
-    
     handleTouchMove(event) {
-      if (!this.$refs.pageImageRef || !this.isZooming) return;
-      
-      // Prevent default to avoid page scrolling
       event.preventDefault();
-      
+      if (!this.isZooming) return;
       const touch = event.touches[0];
-      this.lastTouchX = touch.clientX;
-      this.lastTouchY = touch.clientY;
-      
       const rect = this.$refs.pageImageRef.getBoundingClientRect();
       const x = ((touch.clientX - rect.left) / rect.width) * 100;
       const y = ((touch.clientY - rect.top) / rect.height) * 100;
-      
       this.transformOrigin = `${x}% ${y}%`;
     },
-    
-    handleTouchEnd(event) {
-      // For mobile, we don't automatically reset zoom on touch end
-      // as the zoom toggle is handled in touch start
-    },
-    
+    handleTouchEnd(event) {},
     resetZoom() {
-      // Only reset zoom on mouse leave if not in small screen mode
       if (!this.smallScreen && !this.isMobile) {
         this.isZooming = false;
       }
     }
   }
-}
+};
 </script>

--- a/search-app/front-end/src/components/BrowseContent.vue
+++ b/search-app/front-end/src/components/BrowseContent.vue
@@ -65,9 +65,11 @@
 
 <script>
 import pageImage from '@/assets/images/try_one.jpeg';
-import api from '@/services/api'; // ✅ Ensure this file exists and uses: `export default axios.create(...)`
+import { inject } from 'vue';
+import api from '@/services/api';
 
 export default {
+  inject: ['selectedRecords'],
   data() {
     return {
       pageImage,
@@ -91,9 +93,10 @@ export default {
       };
     },
   },
-  mounted() {
-    this.loadVolumes();
-    this.loadRecords();
+  async mounted() {
+    await this.loadVolumes();     // ✅ Ensure volumes are available before fetching records
+    this.loadRecords();           // ✅ Will now use correct currentVolume and currentPage
+    console.log(this.selectedRecords); // Confirm injection
   },
   methods: {
     async loadVolumes() {
@@ -167,10 +170,3 @@ export default {
   },
 };
 </script>
-
-<style scoped>
-/* Add minimal styles to make it visible if not styled yet */
-.browse-page {
-  padding: 1rem;
-}
-</style>

--- a/search-app/front-end/src/components/BrowseContent.vue
+++ b/search-app/front-end/src/components/BrowseContent.vue
@@ -1,6 +1,3 @@
-
-import api from '@/services/api';
-
 <template>
   <div class="notification-banner">
     <div class="notification-content">
@@ -120,7 +117,7 @@ import api from '@/services/api';
 <script>
 import pageImage from '@/assets/images/try_one.jpeg';
 import { inject, ref, computed, onMounted } from 'vue';
-import api from '../../services/api';
+import api from 'services/api';
 
 export default {
   data() {

--- a/search-app/front-end/src/components/BrowseContent.vue
+++ b/search-app/front-end/src/components/BrowseContent.vue
@@ -117,7 +117,7 @@
 <script>
 import pageImage from '@/assets/images/try_one.jpeg';
 import { inject, ref, computed, onMounted } from 'vue';
-import api from 'services/api';
+import api from '@/services/api';
 
 export default {
   data() {

--- a/search-app/front-end/src/components/BrowseContent.vue
+++ b/search-app/front-end/src/components/BrowseContent.vue
@@ -115,13 +115,13 @@
 </template>
 
 <script>
-import pageImage from '@/assets/images/try_one.jpeg';
+//import pageImage from '@/assets/images/try_one.jpeg';
 import { inject, ref, computed, onMounted } from 'vue';
 
 export default {
   data() {
     return {
-      pageImage,
+      pageImage:'',
       currentVolume: 1,
       currentPage: 1,
       volumes: {

--- a/search-app/front-end/src/components/BrowseContent.vue
+++ b/search-app/front-end/src/components/BrowseContent.vue
@@ -133,20 +133,8 @@ export default {
         7: 16,
         8: 19
       },
-      records: [
-        {
-          id: 'ARO-1-0001-01',
-          date: '1398-09-30',
-          language: 'Latin',
-          content: 'H Processus Curiarum Balliuorum Isti Sunt...'
-        },
-        {
-          id: 'ARO-1-0001-02',
-          date: '1398-09-30',
-          language: 'Latin',
-          content: 'Quo die Willelmus de Camera pater cum...'
-        }
-      ],
+      records: [],
+      
       // XML Modal properties
       showXmlModal: false,
       currentXmlRecordId: '',
@@ -221,10 +209,12 @@ export default {
       };
     }
   },
-  mounted() {
-    this.loadRecords();
+  async mounted() {
     this.checkDeviceSize();
     window.addEventListener('resize', this.checkDeviceSize);
+
+    await this.loadVolumes();
+    await this.loadRecords();
   },
   unmounted() {
     window.removeEventListener('resize', this.checkDeviceSize);
@@ -233,6 +223,27 @@ export default {
     checkDeviceSize() {
       this.isMobile = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
       this.smallScreen = window.innerWidth <= 768;
+    },
+    async loadVolumes() {
+    try {
+      const response = await axios.get('/api/volumes');
+      this.volumes = response.data;
+    } catch (error) {
+      console.error('Failed to fetch volumes:', error);
+    }
+    },
+    async loadRecords() {
+    try {
+      const response = await axios.get('/api/records', {
+        params: {
+          volume: this.currentVolume,
+          page: this.currentPage
+        }
+      });
+      this.records = response.data.records;
+    } catch (error) {
+      console.error('Failed to fetch records:', error);
+    }
     },
     handleVolumeChange() {
       this.currentPage = 1;

--- a/search-app/front-end/src/components/BrowseContent.vue
+++ b/search-app/front-end/src/components/BrowseContent.vue
@@ -1,3 +1,160 @@
+<script setup>
+import { reactive, onMounted, ref, computed } from 'vue'
+import RecordList from '@/components/RecordList.vue'
+import api from '@/services/api'
+import pageImage from '@/assets/images/try_one.jpeg';
+
+const volumes = [1, 2, 4, 5, 6, 7, 8];
+
+const browseState = reactive({
+  pageImage: null,
+  currentVolume: 1,
+  currentPage: 1, // limited to the length of pages - 1
+  currentPageName: '1',
+  zoomScale: 2.5,
+  isZooming: false,
+  transformOrigin: '0% 0%',
+  pages: []
+  /* pages:
+    [
+      0: {
+        'page': 'page1',
+        'records: [
+          {
+            'date': '1504-03-10'
+            'language': 'latin'
+            'content': 'orgubrwnvwornwreqvwj  ou prirht oa;w',
+            'xml': '<p>orgubrwnvwornwreqvwj  ou prirht oa;w<p>'
+          },
+          {
+            'date': '1489-03-11'
+            'language': 'latin'
+            'content': 'greioiwfm;vinfobightnprmwvpin',
+            'xml': '<p>greioiwfm;vinfobightnprmwvpin<p>'
+          },
+        ]
+      },
+      1: {
+        'page': 'page2',
+        'records: [
+          {
+            'date': '1509-09-15'
+            'language': 'multiple'
+            'content': 'OGURBV UeBIUOHEV',
+            'xml': '<p>OGURBV UeBIUOHEV<p>'
+          },
+          {
+            'date': '1510-01-02'
+            'language': 'middle scots'
+            'content': 'urgi)*98YHubqiGJNRVV OUH',
+            'xml': '<p>urgi)*98YHubqiGJNRVV OUH<p>'
+          },
+        ]
+      },
+        etc...
+    ]
+  */
+})
+
+function onChangeVolume(){
+  // update browseState and load relevant records
+  loadRecordsForSingleVolume();
+}
+
+function displayPageImage(){
+  // display placeholder page for now
+  browseState.pageImage = pageImage;
+
+  // display corresponding image here ...
+}
+
+const loadRecordsForSingleVolume = async (volume) => {
+  // fetch records from back end
+  try {
+    const response = await api.get('/records', {params: {volume: volume}});
+    browseState.pages = response.data.records;
+    displayPageImage()
+    
+  } catch (error) {
+    console.error('Failed to fetch volumes:', error);
+  }
+
+}
+
+const goToFirstPage = () => browseState.currentPage = 1;
+
+const goToLastPage = () => browseState.currentPage = browseState.pages.length;
+
+const goToPrevPage = () => { if (browseState.currentPage > 1) browseState.currentPage--; }
+
+const goToNextPage = () => { if (browseState.currentPage < browseState.pages.length) { browseState.currentPage++; } }
+
+const goToSpecificPage = () => {
+  const max = browseState.pages.length;
+  if (browseState.currentPage < 1) browseState.currentPage = 1;
+  else if (browseState.currentPage > max) browseState.currentPage = max;
+}
+
+const currentRecords = computed(() => {
+  return browseState.pages?.[browseState.currentPage - 1]?.records || [];
+});
+
+// image stuff
+const pageImageRef = ref(null);
+
+function handleZoom(event) {
+  const rect = pageImageRef.getBoundingClientRect();
+  const x = ((event.clientX - rect.left) / rect.width) * 100;
+  const y = ((event.clientY - rect.top) / rect.height) * 100;
+  browseState.transformOrigin = `${x}% ${y}%`;
+  browseState.isZooming = true;
+}
+function toggleZoom(event) {
+  const rect = pageImageRef.getBoundingClientRect();
+  const x = ((event.clientX - rect.left) / rect.width) * 100;
+  const y = ((event.clientY - rect.top) / rect.height) * 100;
+  browseState.transformOrigin = `${x}% ${y}%`;
+  browseState.isZooming = !browseState.isZooming;
+}
+function resetZoom() {
+  browseState.isZooming = false;
+}
+
+const imageStyle = computed(() => {
+  if (!browseState.isZooming) {
+    return { transform: 'scale(1)' };
+  }
+  return {
+    transform: `scale(${browseState.zoomScale})`,
+    transformOrigin: browseState.transformOrigin,
+  };
+});
+
+
+const setBrowseStateValues = () => {
+    // parse the url
+    const urlParams = new URLSearchParams(window.location.search);
+    browseState.currentVolume = urlParams.get('volume') || browseState.currentVolume;
+    browseState.currentPage = urlParams.get('page') || browseState.currentPage;
+};
+
+onMounted(() => {
+  setBrowseStateValues();
+  // if volume or volume and page not specified, try loading first page of first volume.
+  if (!volumes.includes(browseState.currentVolume) ){
+    // try loading first volume
+    alert('volume does not exist')
+
+  } else {
+    // load according to url parameters
+    loadRecordsForSingleVolume(browseState.currentVolume)
+  }
+
+  // placeholder image for now
+  
+})
+</script>
+
 <template>
   <div class="browse-page">
     <main class="content">
@@ -12,8 +169,8 @@
 
       <div class="container-browser">
         <div class="volume-nav">
-          <select class="volume-select" v-model="currentVolume" @change="handleVolumeChange">
-            <option v-for="(pageCount, volId) in volumes" :key="volId" :value="Number(volId)">
+          <select class="volume-select" v-model="browseState.currentVolume" @change="onChangeVolume">
+            <option v-for="volId in volumes" :key="volId" :value="volId">
               Volume {{ volId }}
             </option>
           </select>
@@ -22,7 +179,7 @@
         <div class="split-view">
           <div class="image-viewer" ref="imageViewer">
             <img
-              :src="pageImage"
+              :src="browseState.pageImage"
               alt="Page Image"
               class="page-image"
               @mousemove="handleZoom"
@@ -38,16 +195,17 @@
               <button class="nav-btn" @click="goToFirstPage">&lt;&lt;</button>
               <button class="nav-btn" @click="goToPrevPage" :disabled="currentPage <= 1">&lt;</button>
 
-              <input type="number" v-model.number="currentPage" min="1" :max="volumes[currentVolume]" @keyup.enter="goToSpecificPage" />
-              <span>of {{ volumes[currentVolume] }}</span>
+              <input type="string" v-model="browseState.currentPage" min="1" :max="browseState.pages.length" @keyup.enter="goToSpecificPage" />
+              <span>of {{ browseState.pages.length }}</span>
               <button class="page-go-btn" @click="goToSpecificPage">Go</button>
 
-              <button class="nav-btn" @click="goToNextPage" :disabled="currentPage >= volumes[currentVolume]">&gt;</button>
+              <button class="nav-btn" @click="goToNextPage" :disabled="browseState.currentPage >= browseState.pages.length">&gt;</button>
               <button class="nav-btn" @click="goToLastPage">&gt;&gt;</button>
             </div>
+            <RecordList :records="currentRecords"/>
 
             <div class="records">
-              <div v-for="record in records" :key="record.id" class="record-item">
+              <div v-for="record in currentRecords" :key="record.id" class="record-item">
                 <div class="record-header">
                   <div>ID: {{ record.id }}</div>
                   <div>Date: {{ record.date }}</div>
@@ -63,7 +221,7 @@
   </div>
 </template>
 
-<script>
+<!-- <script>
 import pageImage from '@/assets/images/try_one.jpeg';
 import { inject } from 'vue';
 import api from '@/services/api';
@@ -169,4 +327,4 @@ export default {
     },
   },
 };
-</script>
+</script> -->

--- a/search-app/front-end/src/components/BrowseContent.vue
+++ b/search-app/front-end/src/components/BrowseContent.vue
@@ -115,13 +115,13 @@
 </template>
 
 <script>
-//import pageImage from '@/assets/images/try_one.jpeg';
+import pageImage from '@/assets/images/try_one.jpeg';
 import { inject, ref, computed, onMounted } from 'vue';
 
 export default {
   data() {
     return {
-      pageImage:'',
+      pageImage,
       currentVolume: 1,
       currentPage: 1,
       volumes: {

--- a/search-app/front-end/src/components/BrowseContent.vue
+++ b/search-app/front-end/src/components/BrowseContent.vue
@@ -72,6 +72,7 @@ const loadRecordsForSingleVolume = async (volume) => {
   // fetch records from back end
   try {
     const response = await api.get('/records', {params: {volume: volume}});
+    // store list of pages containing lists of records
     browseState.pages = response.data.records;
     displayPageImage()
     

--- a/search-app/front-end/src/components/BrowseContent.vue
+++ b/search-app/front-end/src/components/BrowseContent.vue
@@ -1,8 +1,9 @@
 <script setup>
-import { reactive, onMounted, ref, computed } from 'vue'
-import RecordList from '@/components/RecordList.vue'
-import api from '@/services/api'
+import { reactive, onMounted, ref, computed } from 'vue';
+import RecordList from '@/components/RecordList.vue';
+import api from '@/services/api';
 import pageImage from '@/assets/images/try_one.jpeg';
+import LoadingAnimation from '@/components/LoadingAnimation.vue';
 
 const volumes = [1, 2, 4, 5, 6, 7, 8];
 
@@ -216,8 +217,8 @@ onMounted(() => {
               <button class="nav-btn" @click="goToLastPage">&gt;&gt;</button>
             </div>
              <!-- Display loading text if pages are loading -->
-             <div v-if="browseState.pagesLoading" class="loading-text">
-              Loading records, please wait...
+             <div v-if="browseState.pagesLoading">
+                <LoadingAnimation :loadingText="'Loading records, please wait'"/>
             </div>
 
             <!-- Display records once loading is complete -->

--- a/search-app/front-end/src/components/BrowseContent.vue
+++ b/search-app/front-end/src/components/BrowseContent.vue
@@ -18,45 +18,6 @@ const browseState = reactive({
   pagesLoading: true,
   cachedPages: {},
   pages: []
-  /* pages:
-    [
-      0: {
-        'page': 'page1',
-        'records: [
-          {
-            'date': '1504-03-10'
-            'language': 'latin'
-            'content': 'orgubrwnvwornwreqvwj  ou prirht oa;w',
-            'xml': '<p>orgubrwnvwornwreqvwj  ou prirht oa;w<p>'
-          },
-          {
-            'date': '1489-03-11'
-            'language': 'latin'
-            'content': 'greioiwfm;vinfobightnprmwvpin',
-            'xml': '<p>greioiwfm;vinfobightnprmwvpin<p>'
-          },
-        ]
-      },
-      1: {
-        'page': 'page2',
-        'records: [
-          {
-            'date': '1509-09-15'
-            'language': 'multiple'
-            'content': 'OGURBV UeBIUOHEV',
-            'xml': '<p>OGURBV UeBIUOHEV<p>'
-          },
-          {
-            'date': '1510-01-02'
-            'language': 'middle scots'
-            'content': 'urgi)*98YHubqiGJNRVV OUH',
-            'xml': '<p>urgi)*98YHubqiGJNRVV OUH<p>'
-          },
-        ]
-      },
-        etc...
-    ]
-  */
 })
 
 function onChangeVolume(){
@@ -172,14 +133,14 @@ onMounted(() => {
 <template>
   <div class="browse-page">
     <main class="content">
-      <div class="notification-banner">
+      <!-- <div class="notification-banner">
         <div class="notification-content">
           <div class="notification-icon">ℹ️</div>
           <div class="notification-text">
             <strong>Please Note:</strong> While the Browse page UI is fully functional, it currently displays a placeholder record only. The record fetching functionality is still a work in progress and will be implemented in a future update.
           </div>
         </div>
-      </div>
+      </div> -->
 
       <div class="container-browser">
         <div class="volume-nav">
@@ -223,128 +184,9 @@ onMounted(() => {
 
             <!-- Display records once loading is complete -->
             <RecordList v-if="!browseState.pagesLoading" :records="currentRecords"/>
-
-            <!-- <div class="records">
-              <div v-for="record in currentRecords" :key="record.id" class="record-item">
-                <div class="record-header">
-                  <div>ID: {{ record.id }}</div>
-                  <div>Date: {{ record.date }}</div>
-                  <div>Language: {{ record.language }}</div>
-                </div>
-                <div class="record-content">{{ record.content }}</div>
-              </div>
-            </div> -->
           </div>
         </div>
       </div>
     </main>
   </div>
 </template>
-
-<!-- <script>
-import pageImage from '@/assets/images/try_one.jpeg';
-import { inject } from 'vue';
-import api from '@/services/api';
-
-export default {
-  inject: ['selectedRecords'],
-  data() {
-    return {
-      pageImage,
-      currentVolume: 1,
-      currentPage: 1,
-      volumes: {},
-      records: [],
-      zoomScale: 2.5,
-      isZooming: false,
-      transformOrigin: '0% 0%',
-    };
-  },
-  computed: {
-    imageStyle() {
-      if (!this.isZooming) {
-        return { transform: 'scale(1)' };
-      }
-      return {
-        transform: `scale(${this.zoomScale})`,
-        transformOrigin: this.transformOrigin,
-      };
-    },
-  },
-  async mounted() {
-    await this.loadVolumes();     // ✅ Ensure volumes are available before fetching records
-    this.loadRecords();           // ✅ Will now use correct currentVolume and currentPage
-    console.log(this.selectedRecords); // Confirm injection
-  },
-  methods: {
-    async loadVolumes() {
-      try {
-        const response = await api.get('/volumes');
-        this.volumes = response.data;
-      } catch (error) {
-        console.error('Failed to fetch volumes:', error);
-      }
-    },
-    async loadRecords() {
-      try {
-        const response = await api.get('/records', {
-          params: {
-            volume: this.currentVolume,
-            page: this.currentPage,
-          },
-        });
-        this.records = response.data.records;
-      } catch (error) {
-        console.error('Failed to fetch records:', error);
-      }
-    },
-    handleVolumeChange() {
-      this.currentPage = 1;
-      this.loadRecords();
-    },
-    goToFirstPage() {
-      this.currentPage = 1;
-      this.loadRecords();
-    },
-    goToPrevPage() {
-      if (this.currentPage > 1) {
-        this.currentPage--;
-        this.loadRecords();
-      }
-    },
-    goToNextPage() {
-      if (this.currentPage < this.volumes[this.currentVolume]) {
-        this.currentPage++;
-        this.loadRecords();
-      }
-    },
-    goToLastPage() {
-      this.currentPage = this.volumes[this.currentVolume];
-      this.loadRecords();
-    },
-    goToSpecificPage() {
-      const max = this.volumes[this.currentVolume];
-      if (this.currentPage < 1) this.currentPage = 1;
-      else if (this.currentPage > max) this.currentPage = max;
-      this.loadRecords();
-    },
-    handleZoom(event) {
-      const rect = this.$refs.pageImageRef.getBoundingClientRect();
-      const x = ((event.clientX - rect.left) / rect.width) * 100;
-      const y = ((event.clientY - rect.top) / rect.height) * 100;
-      this.transformOrigin = `${x}% ${y}%`;
-      this.isZooming = true;
-    },
-    toggleZoom(event) {
-      const rect = this.$refs.pageImageRef.getBoundingClientRect();
-      const x = ((event.clientX - rect.left) / rect.width) * 100;
-      const y = ((event.clientY - rect.top) / rect.height) * 100;
-      this.transformOrigin = `${x}% ${y}%`;
-      this.isZooming = !this.isZooming;
-    },
-    resetZoom() {
-      this.isZooming = false;
-    },
-  },
-};
-</script> -->

--- a/search-app/front-end/src/components/BrowseContent.vue
+++ b/search-app/front-end/src/components/BrowseContent.vue
@@ -1,3 +1,4 @@
+import axios from 'axios'
 <template>
   <div class="notification-banner">
     <div class="notification-content">
@@ -207,8 +208,7 @@ export default {
     window.addEventListener('resize', this.checkDeviceSize);
 
     await this.loadVolumes();
-    //await this.loadRecords();
-    this.handleVolumeChange();
+    await this.loadRecords();
   },
   unmounted() {
     window.removeEventListener('resize', this.checkDeviceSize);

--- a/search-app/front-end/src/components/LoadingAnimation.vue
+++ b/search-app/front-end/src/components/LoadingAnimation.vue
@@ -1,0 +1,44 @@
+<script setup>
+import { reactive, onMounted, onBeforeUnmount } from 'vue';
+
+const props = defineProps({
+    loadingText: {
+        type: String,
+        required: false,
+        default: 'Loading'
+    }
+});
+
+const loadingState = reactive({
+    loadingDots: '.',
+    loadingInterval: null
+});
+
+const startLoadingAnimation = () => {
+  let dotCount = 0;
+  const dotArray = ['.', '..', '...'];
+
+  loadingState.loadingInterval = setInterval(() => {
+    dotCount = (dotCount + 1) % dotArray.length; // Cycle through the dots
+    loadingState.loadingDots = dotArray[dotCount];
+  }, 500);  // Change dots every 500ms (adjust as needed)
+};
+
+onMounted(() => {
+  startLoadingAnimation();
+});
+
+onBeforeUnmount(() => {
+  // Clean up the interval when the component is destroyed
+  if (loadingState.loadingInterval) {
+    clearInterval(loadingState.loadingInterval);
+  }
+});
+</script>
+
+
+<template>
+    <div class="loading-text">
+        {{ loadingText + loadingState.loadingDots }}
+    </div>
+</template>

--- a/search-app/front-end/src/components/Record.vue
+++ b/search-app/front-end/src/components/Record.vue
@@ -32,7 +32,7 @@ const props = defineProps({
         <div class="record-header">
         <div>ID: {{ props.record.id }}</div>
         <div>Date: {{ props.record.date }}</div>
-        <div>Language: {{ props.record.language }}</div>
+        <div>Language: {{ props.record.lang }}</div>
     </div>
          <!-- add button to switch between content and xml -->
         <div class="record-content">{{ props.record.content }}</div>

--- a/search-app/front-end/src/components/Record.vue
+++ b/search-app/front-end/src/components/Record.vue
@@ -1,4 +1,5 @@
 <script setup>
+import { ref } from 'vue';
 
 const props = defineProps({
     record: {
@@ -10,7 +11,7 @@ const props = defineProps({
             type: String,
             required: false
         },
-        language: {
+        lang: {
             type: String,
             required: false
         },
@@ -18,23 +19,42 @@ const props = defineProps({
             type: String,
             required: true
         },
-        xml: {
+        xml_content: {
             type: String,
             required: true
         }
     }
     
-})
+});
+
+// Reactive variable to control the display content
+const showXml = ref(false);
+
+// Toggle the content when the button is clicked
+const toggleContent = () => {
+  showXml.value = !showXml.value;
+};
 </script>
 
 <template>
     <div>
         <div class="record-header">
-        <div>ID: {{ props.record.id }}</div>
-        <div>Date: {{ props.record.date }}</div>
-        <div>Language: {{ props.record.lang }}</div>
-    </div>
-         <!-- add button to switch between content and xml -->
-        <div class="record-content">{{ props.record.content }}</div>
+            <div>ID: {{ record.id }}</div>
+            <div>Date: {{ record.date }}</div>
+            <div>Language: {{ record.lang }}</div>
+        </div>
+
+        <!-- Display either content or xml_content based on showXml value -->
+        <div class="record-content">
+            <div v-if="showXml">
+                <pre class="records-container">{{ record.xml_content }}</pre> <!-- Wrap XML content in <pre> tag -->
+            </div>
+            <div v-else>{{ record.content }}</div>
+        </div>
+
+        <!-- Button to toggle content -->
+        <button class="xml-btn" @click="toggleContent">
+            {{ showXml ? 'Switch to Content' : 'Switch to XML' }}
+        </button>
      </div>
 </template>

--- a/search-app/front-end/src/components/Record.vue
+++ b/search-app/front-end/src/components/Record.vue
@@ -1,5 +1,7 @@
 <script setup>
-import { ref } from 'vue';
+import { ref, onMounted } from 'vue';
+
+const saved = ref(false);
 
 const props = defineProps({
     record: {
@@ -34,6 +36,22 @@ const showXml = ref(false);
 const toggleContent = () => {
   showXml.value = !showXml.value;
 };
+
+const addToSelected = () => {
+    // add contents of record to collection of saved records
+    if (!saved.value){
+        alert('Added Entry:\n' + JSON.stringify(props.record, null, 2));
+        // do stuff
+    } else {
+        alert('Removed Entry from Saved');
+        // do stuff
+    }
+    saved.value = !saved.value;
+}
+
+onMounted(() => {
+    // determine the value of saved
+})
 </script>
 
 <template>
@@ -58,6 +76,11 @@ const toggleContent = () => {
         <!-- Button to toggle content -->
         <button class="xml-btn" @click="toggleContent">
             {{ showXml ? 'Switch to Content' : 'Switch to XML' }}
+        </button>
+
+        <!-- Button to toggle content -->
+        <button class="xml-btn" @click="addToSelected">
+            {{ saved ? 'Remove from Saved' : 'Save' }}
         </button>
      </div>
 </template>

--- a/search-app/front-end/src/components/Record.vue
+++ b/search-app/front-end/src/components/Record.vue
@@ -1,0 +1,40 @@
+<script setup>
+
+const props = defineProps({
+    record: {
+        id: {
+            type: String,
+            required: true
+        },
+        date: {
+            type: String,
+            required: false
+        },
+        language: {
+            type: String,
+            required: false
+        },
+        content: {
+            type: String,
+            required: true
+        },
+        xml: {
+            type: String,
+            required: true
+        }
+    }
+    
+})
+</script>
+
+<template>
+    <div>
+        <div class="record-header">
+        <div>ID: {{ props.record.id }}</div>
+        <div>Date: {{ props.record.date }}</div>
+        <div>Language: {{ props.record.language }}</div>
+    </div>
+         <!-- add button to switch between content and xml -->
+        <div class="record-content">{{ props.record.content }}</div>
+     </div>
+</template>

--- a/search-app/front-end/src/components/Record.vue
+++ b/search-app/front-end/src/components/Record.vue
@@ -47,7 +47,10 @@ const toggleContent = () => {
         <!-- Display either content or xml_content based on showXml value -->
         <div class="record-content">
             <div v-if="showXml">
+                
+                <!-- PLEASE HELP STYLE THIS -->
                 <pre class="records-container">{{ record.xml_content }}</pre> <!-- Wrap XML content in <pre> tag -->
+            
             </div>
             <div v-else>{{ record.content }}</div>
         </div>

--- a/search-app/front-end/src/components/RecordList.vue
+++ b/search-app/front-end/src/components/RecordList.vue
@@ -1,0 +1,18 @@
+<script setup>
+import Record from '@/components/Record.vue'
+import pageImage from '@/assets/images/try_one.jpeg';
+const props = defineProps({
+    records: {
+        type: Object,
+        required: true
+    }
+})
+</script>
+
+<template>
+    <div class="records">
+        <div v-for="record in props.records" :key="record.id" class="record-item">
+            <Record :record="record"/>
+        </div>
+    </div>
+</template>

--- a/search-app/front-end/src/components/RecordList.vue
+++ b/search-app/front-end/src/components/RecordList.vue
@@ -1,6 +1,7 @@
 <script setup>
-import Record from '@/components/Record.vue'
-import pageImage from '@/assets/images/try_one.jpeg';
+import { onMounted } from 'vue';
+import Record from '@/components/Record.vue';
+
 const props = defineProps({
     records: {
         type: Object,
@@ -11,7 +12,7 @@ const props = defineProps({
 
 <template>
     <div class="records">
-        <div v-for="record in props.records" :key="record.id" class="record-item">
+        <div v-for="record in records" :key="record.id" class="record-item">
             <Record :record="record"/>
         </div>
     </div>

--- a/search-app/front-end/src/components/SearchResultCard.vue
+++ b/search-app/front-end/src/components/SearchResultCard.vue
@@ -44,7 +44,8 @@ function copyHtmlContent() {
 // opens the content in the browse page
 const openContentInBrowse = () => {
     const browseParams = {
-        id: props.id
+        volume: props.htmlvolume,
+        docPage: props.htmlpage
     };
     router.push({
         name: 'browse',

--- a/search-app/front-end/src/router/index.js
+++ b/search-app/front-end/src/router/index.js
@@ -1,4 +1,5 @@
 import { createRouter, createWebHistory } from 'vue-router'
+import BrowseView from '@/views/BrowseView.vue';
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -11,7 +12,7 @@ const router = createRouter({
     {
       path: '/browse',
       name: 'browse',
-      component: () => import('@/views/BrowseView.vue'),
+      component: BrowseView.vue,
     },
     {
       path: '/search',

--- a/search-app/front-end/src/router/index.js
+++ b/search-app/front-end/src/router/index.js
@@ -1,5 +1,4 @@
 import { createRouter, createWebHistory } from 'vue-router'
-import BrowseView from '@/views/BrowseView.vue';
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -12,7 +11,8 @@ const router = createRouter({
     {
       path: '/browse',
       name: 'browse',
-      component: BrowseView.vue,
+      component: () => import('@/views/BrowseView.vue'),
+
     },
     {
       path: '/search',

--- a/search-app/front-end/src/services/api.js
+++ b/search-app/front-end/src/services/api.js
@@ -1,0 +1,8 @@
+// src/services/api.js
+import axios from 'axios';
+
+const api = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000/api',
+});
+
+export default api; // <-- this line is ESSENTIAL

--- a/search-app/front-end/src/services/browseCache.js
+++ b/search-app/front-end/src/services/browseCache.js
@@ -1,0 +1,21 @@
+const browseCache = {
+    // Cache for storing the loaded records
+    _recordsCache: {},
+  
+    // Check if records for a specific volume are cached
+    hasRecords(volume) {
+      return this._recordsCache.hasOwnProperty(volume);
+    },
+
+    // Get records for a specific volume
+    getRecords(volume) {
+      return this._recordsCache[volume] || [];
+    },
+
+    // Store records for a specific volume
+    setRecords(volume, records) {
+      this._recordsCache[volume] = records;
+    }
+};
+  
+export default browseCache;

--- a/search-app/front-end/src/views/BrowseView.vue
+++ b/search-app/front-end/src/views/BrowseView.vue
@@ -1,14 +1,12 @@
-<script setup>
-import BrowseContent from '@/components/BrowseContent.vue';
-</script>
-
 <template>
     <div class="browse-page">
-        <!-- Main Section -->
-        <main class="content">
-            <BrowseContent />
-        </main>
+      <main class="content">
+        <BrowseContent />
+      </main>
     </div>
-</template>
-
-
+  </template>
+  
+  <script setup>
+  import BrowseContent from '@/components/BrowseContent.vue';
+  </script>
+  


### PR DESCRIPTION
completed:
- using Advanced Search and other python scripts to retrieve, categorize, and sort entry records
- only using xml files to fetch raw xml string
- all entries displaying correctly and on their corresponding document page
- toggle between content and xml view
- can browse using url query as well. works with the following params: volume, page, docPage, and docId
- animated loading text
- blocking out browse fields while records are loading
- memory cache for records and page numbers when switching between navbar tabs. Loading of data only required upon refresh of website. 
- refactored haziel's front end components to be more modular and consistent
- removed go button because switching between pages is now instantaneous
- linked up search entries with browsing page

still need to do the following:
- make scrollable viewport for xml with normal width. xml acting weird when switching between light and dark mode.
- maybe style volume and page header above document image?
- add selection functionality to save button for each entry. Link up with fariha's work?
- link up images (no access to image files currently)
- box for page number input is a bit long